### PR TITLE
Allow (simulated) display to be used with ci builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ install:
   # Set Xvfb to listen for connections on frame buffer 99 ("Xvfb :99"), and dump STDOUT and STDERR 
   # output ("> /dev/null 2>&1"). This means that data printed from tests to std::cout or std::cerr 
   # will not show in CI output. 
-  - Xvfb :99 > /dev/null 2>&1
+  - Xvfb :99 > /dev/null 2>&1 &
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Create a ``.travis.yml`` file in the base of you repo similar to:
 # This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
 sudo: required
 dist: trusty
+# apt-get install xvfb. Xvfb is an X server that can be run on machines without display hardware or 
+# physical input devices.
 addons:
   apt:
     packages:
@@ -44,8 +46,13 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO="kinetic"  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
 install:
+  # Set the display to virtual frame buffer 99. 99 is used because it is not likely to be in use for 
+  # something else 
   - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+  # Set Xvfb to listen for connections on frame buffer 99 ("Xvfb :99"), and dump STDOUT and STDERR 
+  # output ("> /dev/null 2>&1"). This means that data printed from tests to std::cout or std::cerr 
+  # will not show in CI output. 
+  - Xvfb :99 > /dev/null 2>&1
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Create a ``.travis.yml`` file in the base of you repo similar to:
 # This config file for Travis CI utilizes https://github.com/ros-planning/moveit_ci/ package.
 sudo: required
 dist: trusty
+addons:
+  apt:
+    packages:
+        - xvfb
 services:
   - docker
 language: generic
@@ -39,6 +43,9 @@ env:
 matrix:
   allow_failures:
     - env: ROS_DISTRO="kinetic"  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall
+install:
+  - export DISPLAY=':99.0'
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:

--- a/travis.sh
+++ b/travis.sh
@@ -33,6 +33,7 @@ if ! [ "$IN_DOCKER" ]; then
         -e CI_PARENT_DIR \
         -e UPSTREAM_WORKSPACE \
         -e TRAVIS_BRANCH \
+        -e TEST_BLACKLIST
         -e "DISPLAY" \
         -e "QT_X11_NO_MITSHM=1" \
         -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \

--- a/travis.sh
+++ b/travis.sh
@@ -33,7 +33,9 @@ if ! [ "$IN_DOCKER" ]; then
         -e CI_PARENT_DIR \
         -e UPSTREAM_WORKSPACE \
         -e TRAVIS_BRANCH \
-        -e TEST_BLACKLIST \
+        -e "DISPLAY" \
+        -e "QT_X11_NO_MITSHM=1" \
+        -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
         -v $(pwd):/root/$REPOSITORY_NAME moveit/moveit_docker:moveit-$ROS_DISTRO-ci \
         /bin/bash -c "cd /root/$REPOSITORY_NAME; source .moveit_ci/travis.sh;"
     return_value=$?

--- a/travis.sh
+++ b/travis.sh
@@ -35,7 +35,6 @@ if ! [ "$IN_DOCKER" ]; then
         -e TRAVIS_BRANCH \
         -e TEST_BLACKLIST \
         -e "DISPLAY" \
-        -e "QT_X11_NO_MITSHM=1" \
         -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \
         -v $(pwd):/root/$REPOSITORY_NAME moveit/moveit_docker:moveit-$ROS_DISTRO-ci \
         /bin/bash -c "cd /root/$REPOSITORY_NAME; source .moveit_ci/travis.sh;"

--- a/travis.sh
+++ b/travis.sh
@@ -33,7 +33,7 @@ if ! [ "$IN_DOCKER" ]; then
         -e CI_PARENT_DIR \
         -e UPSTREAM_WORKSPACE \
         -e TRAVIS_BRANCH \
-        -e TEST_BLACKLIST
+        -e TEST_BLACKLIST \
         -e "DISPLAY" \
         -e "QT_X11_NO_MITSHM=1" \
         -v "/tmp/.X11-unix:/tmp/.X11-unix:rw" \


### PR DESCRIPTION
This now allows a display to be used in ci testing. I tested this with the moveit_ros repo, the mesh_filter tests are no longer disabled meaning there is a display detected. 

I found the xvfb instructions on someone else's repository (lost the link) after the instructions from travis [here](https://docs.travis-ci.com/user/gui-and-headless-browsers/) didn't work. As I understand it xvfb is used to simulate a display on virtual frame buffer 99. I think 99 is used because it is less likely to be used for something else (see [here](https://www.keyup.eu/en/blog/100-integrating-selenium-into-jenkins)).

The change to travis.sh allows the display simulated by xvfb to be used in Docker. This was implemented following the wiki instructions [here](http://wiki.ros.org/docker/Tutorials/GUI) (thanks for the link @davetcoleman !).
