### PR TITLE
Allow blacklisting packages for testing.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -33,6 +33,7 @@ if ! [ "$IN_DOCKER" ]; then
         -e CI_PARENT_DIR \
         -e UPSTREAM_WORKSPACE \
         -e TRAVIS_BRANCH \
+        -e TEST_BLACKLIST \
         -v $(pwd):/root/$REPOSITORY_NAME moveit/moveit_docker:moveit-$ROS_DISTRO-ci \
         /bin/bash -c "cd /root/$REPOSITORY_NAME; source .moveit_ci/travis.sh;"
     return_value=$?
@@ -142,7 +143,8 @@ my_travis_wait 60 catkin build --no-status --summarize || exit 1
 travis_run source install/setup.bash;
 
 # Only run tests on the current repo's packages
-TEST_PKGS=$(catkin_topological_order $CI_SOURCE_PATH --only-names)
+echo "Test blacklist: $TEST_BLACKLIST"
+TEST_PKGS=$(catkin_topological_order src --only-names | grep -Fvxf <(echo "$TEST_BLACKLIST" | tr ' ;,' '\n'))
 if [ -n "$TEST_PKGS" ]; then
     TEST_PKGS="--no-deps $TEST_PKGS";
 fi


### PR DESCRIPTION
This PR adds an environment variable `TEST_BLACKLIST` for blacklisting packages (allowed separators are a space, comma or semicolon) from the test phase. Not sure if it is something you want to have in general, but it was useful for doing the fcl 0.5 CI test.

So, I figured why not put it up for review, see if it's useful enough to merge :)