### PR TITLE
Allow tests to be skipped manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ notifications:
       # - user@email.com
 env:
   matrix:
-    - ROS_DISTRO="jade"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall
-    - ROS_DISTRO="jade"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall
-    - ROS_DISTRO="jade"  ROS_REP=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
+    - ROS_DISTRO="jade"  ROS_REP=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
     - ROS_DISTRO="jade"  ROS_REP=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
 before_script:
   - mkdir .moveit_ci


### PR DESCRIPTION
Updated version of #8 that preserves the behaviour of only testing packages from the relevant repository.