### PR TITLE
Switch to faster docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ notifications:
       # - user@email.com
 env:
   matrix:
-    - ROS_DISTRO="jade"  ROS_REP=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
-    - ROS_DISTRO="jade"  ROS_REP=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
+    - ROS_DISTRO="kinetic"  ROS_REP=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
+    - ROS_DISTRO="kinetic"  ROS_REP=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
 before_script:
   - mkdir .moveit_ci
   - mv * .moveit_ci # pretend this was cloned


### PR DESCRIPTION
Do not merge - experimental only

Frequently our moveit/moveit:*-source builds are timing out on Dockerhub
https://hub.docker.com/r/moveit/moveit/builds/

And we're eventually going to timeout our travis builds. This aims to increase the speed by pre-installing all the dependencies

# Methodology

- Dockerhub builds a ``moveit/moveit:kinetic-ci`` container 
   - the container pre-downloads all the source from Kinetic's [moveit.rosinstall](https://github.com/ros-planning/moveit/blob/kinetic-devel/moveit.rosinstall)
   - the container runs rosdep on the source to get *all* the dependencies needed
   - the container is re-built everytime a change is made to the ``moveit`` repo or to the OSRF image of ``kinetic-desktop``, by auto-trigger, so it should not lag behind the latest dependencies too much. lately it gets rebuilt every couple hours
- When Travis is run, it pulls the latest ``moveit/moveit:kinetic-ci`` container that essentially has a lot of caching pre-built into it
    - Travis then removes all the source that was pre-downloaded (TODO: maybe skip this step)
    - Travis downloads the latest source code, including the new PR being testing the change
    - Travis builds the repo and runs tests like normal
