### PR TITLE
Use two different Docker images - "ci" or "ci-shadow-fixed"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ compiler:
 notifications:
   email:
     recipients:
-      # - user@email.com
+       - dave@dav.ee
 env:
   matrix:
-    - ROS_DISTRO="jade"  ROS_REP=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
-    - ROS_DISTRO="jade"  ROS_REP=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit_docs/jade-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
+    - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
 before_script:
   - mkdir .moveit_ci
   - mv * .moveit_ci # pretend this was cloned

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ notifications:
       # - user@email.com
 env:
   matrix:
-    - ROS_DISTRO="kinetic"  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
-    - ROS_DISTRO="kinetic"  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+    - ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+    - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
 matrix:
   allow_failures:
-    - env: ROS_DISTRO="kinetic"  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+    - env: ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:
@@ -49,9 +49,12 @@ script:
 
 - ROS_DISTRO: (required) which version of ROS i.e. kinetic
 - ROS_REPO: (default: ros-shadow-fixed) install ROS debians from either regular release or from shadow-fixed, i.e. http://packages.ros.org/ros-shadow-fixed/ubuntu
-- ROS_REPOSITORY\_PATH: (DEPRECATED) replaced by ROS\_REPO, but both still work
 - BEFORE_SCRIPT: (default: not set): Used to specify shell commands or scripts that run before building packages.
 - UPSTREAM_WORKSPACE (default: debian): When set as "file", the dependended packages that need to be built from source are downloaded based on a .rosinstall file in your repository. When set to a "http" URL, this downloads the rosinstall configuration from an http location
 - TEST_BLACKLIST: Allow certain tests to be skipped if necessary (not recommended)
 
 More configurations as seen in [industrial_ci](https://github.com/ros-industrial/industrial_ci) can be added, in the future.
+
+## Removed Configuration
+
+- ROS_REPOSITORY\_PATH: (UNSUPPORTED) replaced by ROS\_REPO


### PR DESCRIPTION
- Use two different Docker images - "ci" or "ci-shadow-fixed"
- Ends support for ROS_REPOSITORY_PATH option
- Updates test for merged moveit repo