### PR TITLE
Create test for clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ env:
   matrix:
     - ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
     - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+    - TEST=clang-format
 matrix:
   allow_failures:
     - env: ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
@@ -52,12 +53,17 @@ script:
 - BEFORE_SCRIPT: (default: not set): Used to specify shell commands or scripts that run before building packages.
 - UPSTREAM_WORKSPACE (default: debian): When set as "file", the dependended packages that need to be built from source are downloaded based on a .rosinstall file in your repository. When set to a "http" URL, this downloads the rosinstall configuration from an http location
 - TEST_BLACKLIST: Allow certain tests to be skipped if necessary (not recommended)
+- TEST: allow other tests to be run, such as code format checking using clang-format
 
-More configurations as seen in [industrial_ci](https://github.com/ros-industrial/industrial_ci) can be added, in the future.
+More configurations as seen in [industrial_ci](https://github.com/ros-industrial/industrial_ci) can be added in the future.
 
 ## Removed Configuration
 
 - ROS_REPOSITORY\_PATH: (UNSUPPORTED) replaced by ROS\_REPO
+
+## Clang-Format
+
+A new test is available that checks if the code is properly formatted as specified in the clang-format file found in ``.clang-format``. Use ``TEST=clang-format`` to enable this test.
 
 ## Running Locally For Testing
 

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -1,0 +1,22 @@
+# Install Dependencies
+travis_run sudo apt-get install clang-format-3.6
+
+# Change to source directory. This directory should have its own .clang-format config file
+travis_run cd $CI_SOURCE_PATH
+travis_run ls -la
+
+# Run clang-format
+echo "Running clang-format"
+find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-3.6 -i -style=file
+
+echo "Showing results"
+travis_run git --no-pager diff
+
+# Make sure no changes have occured in repo
+if ! git diff-index --quiet HEAD --; then
+    # changes
+    echo "clang-format test failed: changes required to comply to formatting rules. See diff above.";
+    exit -1
+fi
+
+echo "Passed clang-format test"

--- a/travis.sh
+++ b/travis.sh
@@ -20,6 +20,16 @@ echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME on $ROS_DISTRO"
 # Helper functions
 source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh
 
+# Split for different tests
+for t in $TEST; do
+    case "$t" in
+        "clang-format")
+            source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_clang_format.sh || exit 1
+            exit 0 # This runs as an independent job, separate from the Docker build
+        ;;
+    esac
+done
+
 # Run all CI in a Docker container
 if ! [ "$IN_DOCKER" ]; then
 


### PR DESCRIPTION
As discussed in https://github.com/ros-planning/moveit/issues/242

This is ready to merge - will not change any CI builds until the appropriate config flag is set