### PR TITLE
Add timing UX to each command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,23 +67,24 @@ A new test is available that checks if the code is properly formatted as specifi
 
 ## Running Locally For Testing
 
-To manually run the moveit_ci script without Travis (presumably for testing):
+To manually run the moveit_ci script without Travis (presumably for testing), we will demonstrate with an example using the full moveit repo.
 
 First clone the repo you want to test:
 
     cd ~/
-    git clone https://github.com/davetcoleman/moveit_kinetic_cpp11
-    cd moveit_kinetic_cpp11
+    git clone https://github.com/ros-planning/moveit
+    cd moveit
 
 Next clone the CI script:
 
     git clone https://github.com/ros-planning/moveit_ci .moveit_ci
 
-Define the necessary environmental variables:
+Manually define the necessary environmental variables:
 
+    export TRAVIS_BRANCH=kinetic-devel
     export ROS_DISTRO=kinetic
-    export ROS_REPO=ros-shadow-fixed
     export UPSTREAM_WORKSPACE=moveit.rosinstall
+    export ROS_REPO=ros-shadow-fixed
 
 Start the script
 

--- a/travis.sh
+++ b/travis.sh
@@ -16,7 +16,7 @@ export HIT_ENDOFSCRIPT=false
 export REPOSITORY_NAME=${PWD##*/}
 export CATKIN_WS=/root/ws_moveit
 echo "---"
-echo "Testing branch $TRAVIS_BRANCH of $REPOSITORY_NAME on $ROS_DISTRO"
+echo "Testing branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'"
 
 # Helper functions
 source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh


### PR DESCRIPTION
This enables a feature already available in industrial_ci project: showing run time of each command.

![screenshot from 2016-11-05 10-52-29](https://cloud.githubusercontent.com/assets/561060/20031946/fa192500-a345-11e6-9a39-fa28caab5472.png)
