### PR TITLE
Upgrade to clang 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ More configurations as seen in [industrial_ci](https://github.com/ros-industrial
 
 ## Removed Configuration
 
-- ROS_REPOSITORY\_PATH: (UNSUPPORTED) replaced by ROS\_REPO
+- ROS\_REPOSITORY\_PATH replaced by ROS\_REPO
 
 ## Clang-Format
 
@@ -85,6 +85,8 @@ Manually define the necessary environmental variables:
     export ROS_DISTRO=kinetic
     export UPSTREAM_WORKSPACE=moveit.rosinstall
     export ROS_REPO=ros-shadow-fixed
+    # optional that will not test build but only formatting:
+    export TEST=clang-format
 
 Start the script
 

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -1,5 +1,5 @@
 # Install Dependencies
-travis_run sudo apt-get install clang-format-3.6
+travis_run apt-get install clang-format-3.8
 
 # Change to source directory. This directory should have its own .clang-format config file
 travis_run cd $CI_SOURCE_PATH
@@ -7,7 +7,7 @@ travis_run ls -la
 
 # Run clang-format
 echo "Running clang-format"
-find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-3.6 -i -style=file
+find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-3.8 -i -style=file
 
 echo "Showing changes in code style:"
 git --no-pager diff
@@ -16,7 +16,7 @@ git --no-pager diff
 if ! git diff-index --quiet HEAD --; then
     # changes
     echo "clang-format test failed: changes required to comply to formatting rules. See diff above.";
-    exit -1
+    exit 1 # error
 fi
 
 echo "Passed clang-format test"


### PR DESCRIPTION
Move clang test into docker so Xenial is available for tests

Follow up for https://github.com/ros-planning/moveit/pull/367