### PR TITLE
Add moveit's clang-format file if one not provided

### DIFF
--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -1,9 +1,14 @@
 # Install Dependencies
 travis_run apt-get -qq install -y clang-format-3.8
 
-# Change to source directory. This directory should have its own .clang-format config file
+# Change to source directory.
 travis_run cd $CI_SOURCE_PATH
 travis_run ls -la
+
+# This directory can have its own .clang-format config file but if not, MoveIt's will be provided
+if [ ! -f .clang_format ]; then
+    wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO/.clang-format"
+fi
 
 # Run clang-format
 echo "Running clang-format"


### PR DESCRIPTION
I noticed in moveit_kinematics_tests it was passing the clang format test even though it was not correct style - that repo doesn't have its own copy of .clang-format. Rather than copy it, I'd prefer to use the central on on the moveit repo

https://github.com/ros-planning/moveit_kinematics_tests/pull/10