### PR TITLE
run clang-format outside docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
 
 before_script:
-  - mkdir .moveit_ci
-  - mv * .moveit_ci # pretend this was cloned
+  - ln -s . .moveit_ci
 script:
-  - source .moveit_ci/travis.sh # this is intended only for the repo moveit_ci, other repos should use the .travis.yml script in the README.md
+  - ./travis.sh # this is intended only for the repo moveit_ci, other repos should use the .travis.yml script in the README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
-matrix:
+
 before_script:
   - mkdir .moveit_ci
   - mv * .moveit_ci # pretend this was cloned

--- a/README.md
+++ b/README.md
@@ -25,25 +25,28 @@ sudo: required
 dist: trusty
 services:
   - docker
-language: generic
-compiler:
-  - gcc
+language: cpp
+compiler: gcc
+cache: ccache
+
 notifications:
   email:
     recipients:
       # - user@email.com
 env:
   matrix:
+    - TEST=clang-format
     - ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
     - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
-    - TEST=clang-format
+
 matrix:
   allow_failures:
     - env: ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:
-  - source .moveit_ci/travis.sh
+  - .moveit_ci/travis.sh
 ```
 
 ## Configurations

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -9,7 +9,7 @@ travis_run cd $CI_SOURCE_PATH
 travis_run ls -la
 
 # This directory can have its own .clang-format config file but if not, MoveIt's will be provided
-if [ ! -f .clang_format ]; then
+if [ ! -f .clang-format ]; then
     wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-format"
 fi
 

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -1,3 +1,6 @@
+# Helper functions
+. $(dirname $0)/util.sh
+
 # Install Dependencies
 travis_run apt-get -qq install -y clang-format-3.8
 

--- a/travis.sh
+++ b/travis.sh
@@ -21,6 +21,16 @@ echo "Testing branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'
 # Helper functions
 source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh
 
+# Split for different tests
+for t in $TEST; do
+    case "$t" in
+        "clang-format")
+            sudo bash ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_clang_format.sh || exit 1
+            exit 0 # This runs as an independent job, do not run regular travis test
+        ;;
+    esac
+done
+
 # Run all CI in a Docker container
 if ! [ "$IN_DOCKER" ]; then
 
@@ -73,16 +83,6 @@ travis_run apt-get -qq update
 # Enable ccache
 travis_run apt-get -qq install ccache
 export PATH=/usr/lib/ccache:$PATH
-
-# Split for different tests
-for t in $TEST; do
-    case "$t" in
-        "clang-format")
-            source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_clang_format.sh || exit 1
-            exit 0 # This runs as an independent job, do not run regular travis test
-        ;;
-    esac
-done
 
 # Setup rosdep - note: "rosdep init" is already setup in base ROS Docker image
 travis_run rosdep update


### PR DESCRIPTION
The clang-format check doesn't need to be run within a docker container, which is more time-consuming.