### PR TITLE
cleanup my_travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
 
 before_script:
-  - mkdir .moveit_ci
-  - mv * .moveit_ci # pretend this was cloned
+  - ln -s . .moveit_ci
 script:
-  - source .moveit_ci/travis.sh # this is intended only for the repo moveit_ci, other repos should use the .travis.yml script in the README.md
+  - ./travis.sh # this is intended only for the repo moveit_ci, other repos should use the .travis.yml script in the README.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ notifications:
        - dave@dav.ee
 env:
   matrix:
-    - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
+    - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=travis.rosinstall,travis.rosinstall  # Duplicated .rosinstall file for testing purposes
 
 before_script:
   - ln -s . .moveit_ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
-matrix:
+
 before_script:
   - mkdir .moveit_ci
   - mv * .moveit_ci # pretend this was cloned

--- a/README.md
+++ b/README.md
@@ -25,25 +25,28 @@ sudo: required
 dist: trusty
 services:
   - docker
-language: generic
-compiler:
-  - gcc
+language: cpp
+compiler: gcc
+cache: ccache
+
 notifications:
   email:
     recipients:
       # - user@email.com
 env:
   matrix:
+    - TEST=clang-format
     - ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
     - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
-    - TEST=clang-format
+
 matrix:
   allow_failures:
     - env: ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:
-  - source .moveit_ci/travis.sh
+  - .moveit_ci/travis.sh
 ```
 
 ## Configurations

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -9,7 +9,7 @@ travis_run cd $CI_SOURCE_PATH
 travis_run ls -la
 
 # This directory can have its own .clang-format config file but if not, MoveIt's will be provided
-if [ ! -f .clang_format ]; then
+if [ ! -f .clang-format ]; then
     wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-format"
 fi
 

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -1,3 +1,6 @@
+# Helper functions
+. $(dirname $0)/util.sh
+
 # Install Dependencies
 travis_run apt-get -qq install -y clang-format-3.8
 

--- a/travis.rosinstall
+++ b/travis.rosinstall
@@ -1,0 +1,1 @@
+# This file is intended for testing moveit_ci on travis

--- a/travis.sh
+++ b/travis.sh
@@ -21,6 +21,16 @@ echo "Testing branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'
 # Helper functions
 source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh
 
+# Split for different tests
+for t in $TEST; do
+    case "$t" in
+        "clang-format")
+            sudo bash ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_clang_format.sh || exit 1
+            exit 0 # This runs as an independent job, do not run regular travis test
+        ;;
+    esac
+done
+
 # Run all CI in a Docker container
 if ! [ "$IN_DOCKER" ]; then
 
@@ -73,16 +83,6 @@ travis_run apt-get -qq update
 # Enable ccache
 travis_run apt-get -qq install ccache
 export PATH=/usr/lib/ccache:$PATH
-
-# Split for different tests
-for t in $TEST; do
-    case "$t" in
-        "clang-format")
-            source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/check_clang_format.sh || exit 1
-            exit 0 # This runs as an independent job, do not run regular travis test
-        ;;
-    esac
-done
 
 # Setup rosdep - note: "rosdep init" is already setup in base ROS Docker image
 travis_run rosdep update

--- a/util.sh
+++ b/util.sh
@@ -122,9 +122,9 @@ function my_travis_wait() {
     timeout=20
   fi
 
-  # Show command in console before running
-  local cmd="$@"
-  echo -e "\e[34m$ $cmd\e[0m"
+  local cmd=$@
+  let "TRAVIS_FOLD_COUNTER += 1"
+  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $command
 
   # Disable bash's job control messages
   set +m
@@ -141,9 +141,11 @@ function my_travis_wait() {
     result=$?
     # if process finished before jigger, stop the jigger too
     ps -p$jigger_pid 2>&1>/dev/null && kill $jigger_pid
-  } || return 1
+  }
 
-  echo -e "\nThe command \"$cmd\" exited with $result."
+  echo
+  travis_time_end
+
   return $result
 }
 

--- a/util.sh
+++ b/util.sh
@@ -131,11 +131,13 @@ function my_travis_wait() {
   local cmd="$@"
   echo -e "\e[34m$ $cmd\e[0m"
 
+  # Disable bash's job control messages
+  set +m
   # Run actual command in background
-  $cmd &
+  { $cmd & } 2> /dev/null
   local cmd_pid=$!
 
-  my_travis_jigger $cmd_pid $timeout $cmd &
+  { my_travis_jigger $cmd_pid $timeout $cmd & } 2> /dev/null
   local jigger_pid=$!
   local result
 

--- a/util.sh
+++ b/util.sh
@@ -33,11 +33,11 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #********************************************************************/
 
-# Author: Dave Coleman <dave@dav.ee>
+# Author: Dave Coleman <dave@dav.ee>, Robert Haschke
 # Desc: Utility functions used to make CI work better in Travis
 
 #######################################
-export TRAVIS_FOLD_COUNTER=1
+export TRAVIS_FOLD_COUNTER=0
 
 
 #######################################
@@ -51,7 +51,7 @@ function travis_time_start {
     TRAVIS_START_TIME=$(date +%s%N)
     TRAVIS_TIME_ID=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
     TRAVIS_FOLD_NAME=$1
-    COMMAND=${@:2} # all arguments except the first
+    local COMMAND=${@:2} # all arguments except the first
 
     # Start fold
     echo -e "\e[0Ktravis_fold:start:$TRAVIS_FOLD_NAME"
@@ -67,18 +67,20 @@ function travis_time_start {
 #######################################
 function travis_time_end {
     if [ -z $TRAVIS_START_TIME ]; then
-        echo '[travis_time_end] var TRAVIS_START_TIME is not set. You need to call `travis_time_start` in advance. Rerunning.';
+        echo '[travis_time_end] var TRAVIS_START_TIME is not set. You need to call `travis_time_start` in advance.';
         return;
     fi
-    TRAVIS_END_TIME=$(date +%s%N)
-    TIME_ELAPSED_SECONDS=$(( ($TRAVIS_END_TIME - $TRAVIS_START_TIME)/1000000000 ))
+    local TRAVIS_END_TIME=$(date +%s%N)
+    local TIME_ELAPSED_SECONDS=$(( ($TRAVIS_END_TIME - $TRAVIS_START_TIME)/1000000000 ))
 
     # Output Time
     echo -e "travis_time:end:$TRAVIS_TIME_ID:start=$TRAVIS_START_TIME,finish=$TRAVIS_END_TIME,duration=$(($TRAVIS_END_TIME - $TRAVIS_START_TIME))\e[0K"
     # End fold
     echo -e -n "travis_fold:end:$TRAVIS_FOLD_NAME\e[0m"
 
-    unset $TRAVIS_FOLD_NAME
+    unset TRAVIS_START_TIME
+    unset TRAVIS_TIME_ID
+    unset TRAVIS_FOLD_NAME
 }
 
 #######################################
@@ -90,27 +92,20 @@ function travis_time_end {
 function travis_run() {
   local command=$@
 
-  #echo -e "\e[0Ktravis_fold:start:command$TRAVIS_FOLD_COUNTER \e[34m$ $command\e[0m"
-  travis_time_start moveit_ci$TRAVIS_FOLD_COUNTER $command
-  # actually run command
-  $command || exit 1 # kill build if error
-  travis_time_end moveit_ci$TRAVIS_FOLD_COUNTER
-  #echo -e -n "\e[0Ktravis_fold:end:command$TRAVIS_FOLD_COUNTER\e[0m"
-
   let "TRAVIS_FOLD_COUNTER += 1"
+  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $command
+  # actually run command
+  $command
+  result=$?
+  travis_time_end
+  return $result
 }
 
 #######################################
 # Same as travis_run except ignores errors and does not break build
 function travis_run_true() {
-  local command=$@
-
-  travis_time_start moveit_ci$TRAVIS_FOLD_COUNTER $command
-  # actually run command
-  $command # ignore errors
-  travis_time_end moveit_ci$TRAVIS_FOLD_COUNTER
-
-  let "TRAVIS_FOLD_COUNTER += 1"
+  travis_run $@
+  return 0
 }
 
 #######################################


### PR DESCRIPTION
`my_travis_wait` creates some weird output when finishing:
> /root/moveit/.moveit_ci/util.sh: line 136: 677 Terminated my_travis_jigger $! $timeout $cmd

These are bash's job control messages, which can be suppressed as discussed [here](https://stackoverflow.com/questions/11097761/is-there-a-way-to-make-bash-job-control-quiet).

Furthermore, I dropped the log file, but print any output of the actual command directly.
`my_travis_jigger` simply outputs a single dot each minute.