### PR TITLE
several improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
-matrix:
+
 before_script:
-  - mkdir .moveit_ci
-  - mv * .moveit_ci # pretend this was cloned
+  - ln -s . .moveit_ci # pretend to have the usual location
+
 script:
-  - source .moveit_ci/travis.sh # this is intended only for the repo moveit_ci, other repos should use the .travis.yml script in the README.md
+  - .moveit_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ notifications:
        - dave@dav.ee
 env:
   matrix:
-    - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall BEFORE_SCRIPT="echo 'testing'"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall  # Duplicated tests over the same .rosinstall file for testing purpose only.
+    - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall # Duplicated .rosinstall file for testing purposes
 
 before_script:
   - ln -s . .moveit_ci # pretend to have the usual location

--- a/README.md
+++ b/README.md
@@ -25,25 +25,28 @@ sudo: required
 dist: trusty
 services:
   - docker
-language: generic
-compiler:
-  - gcc
+language: cpp
+compiler: gcc
+cache: ccache
+
 notifications:
   email:
     recipients:
       # - user@email.com
 env:
   matrix:
+    - ROS_DISTRO=kinetic  ROS_REPO=ros  TEST=clang-format
     - ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
     - ROS_DISTRO=kinetic  ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
-    - TEST=clang-format
+
 matrix:
   allow_failures:
     - env: ROS_DISTRO=kinetic  ROS_REPO=ros              UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall
+
 before_script:
   - git clone -q https://github.com/ros-planning/moveit_ci.git .moveit_ci
 script:
-  - source .moveit_ci/travis.sh
+  - .moveit_ci/travis.sh
 ```
 
 ## Configurations

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -6,7 +6,7 @@ travis_run cd $CI_SOURCE_PATH
 travis_run ls -la
 
 # This directory can have its own .clang-format config file but if not, MoveIt's will be provided
-if [ ! -f .clang_format ]; then
+if [ ! -f .clang-format ]; then
     wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-format"
 fi
 

--- a/travis.rosinstall
+++ b/travis.rosinstall
@@ -1,0 +1,1 @@
+# This file is intended for testing moveit_ci on travis

--- a/travis.sh
+++ b/travis.sh
@@ -145,7 +145,7 @@ travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_
 travis_run cd $CATKIN_WS
 
 # Configure catkin
-travis_run catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release
+travis_run catkin config --extend /opt/ros/$ROS_DISTRO --install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3"
 
 # Console output fix for: "WARNING: Could not encode unicode characters"
 export PYTHONIOENCODING=UTF-8

--- a/util.sh
+++ b/util.sh
@@ -33,11 +33,11 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #********************************************************************/
 
-# Author: Dave Coleman <dave@dav.ee>
+# Author: Dave Coleman <dave@dav.ee>, Robert Haschke
 # Desc: Utility functions used to make CI work better in Travis
 
 #######################################
-export TRAVIS_FOLD_COUNTER=1
+export TRAVIS_FOLD_COUNTER=0
 
 
 #######################################
@@ -51,7 +51,7 @@ function travis_time_start {
     TRAVIS_START_TIME=$(date +%s%N)
     TRAVIS_TIME_ID=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 8 | head -n 1)
     TRAVIS_FOLD_NAME=$1
-    COMMAND=${@:2} # all arguments except the first
+    local COMMAND=${@:2} # all arguments except the first
 
     # Start fold
     echo -e "\e[0Ktravis_fold:start:$TRAVIS_FOLD_NAME"
@@ -67,18 +67,20 @@ function travis_time_start {
 #######################################
 function travis_time_end {
     if [ -z $TRAVIS_START_TIME ]; then
-        echo '[travis_time_end] var TRAVIS_START_TIME is not set. You need to call `travis_time_start` in advance. Rerunning.';
+        echo '[travis_time_end] var TRAVIS_START_TIME is not set. You need to call `travis_time_start` in advance.';
         return;
     fi
-    TRAVIS_END_TIME=$(date +%s%N)
-    TIME_ELAPSED_SECONDS=$(( ($TRAVIS_END_TIME - $TRAVIS_START_TIME)/1000000000 ))
+    local TRAVIS_END_TIME=$(date +%s%N)
+    local TIME_ELAPSED_SECONDS=$(( ($TRAVIS_END_TIME - $TRAVIS_START_TIME)/1000000000 ))
 
     # Output Time
     echo -e "travis_time:end:$TRAVIS_TIME_ID:start=$TRAVIS_START_TIME,finish=$TRAVIS_END_TIME,duration=$(($TRAVIS_END_TIME - $TRAVIS_START_TIME))\e[0K"
     # End fold
     echo -e -n "travis_fold:end:$TRAVIS_FOLD_NAME\e[0m"
 
-    unset $TRAVIS_FOLD_NAME
+    unset TRAVIS_START_TIME
+    unset TRAVIS_TIME_ID
+    unset TRAVIS_FOLD_NAME
 }
 
 #######################################
@@ -87,36 +89,36 @@ function travis_time_end {
 # Arguments:
 #   command: action to run
 #######################################
+function travis_run_impl() {
+  local command=$@
+
+  let "TRAVIS_FOLD_COUNTER += 1"
+  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $command
+  # actually run command
+  $command
+  result=$?
+  travis_time_end
+  return $result
+}
+
+#######################################
+# Run a command and do folding and timing for it
+#   Return the exit status of the command
 function travis_run() {
-  local command=$@
-
-  #echo -e "\e[0Ktravis_fold:start:command$TRAVIS_FOLD_COUNTER \e[34m$ $command\e[0m"
-  travis_time_start moveit_ci$TRAVIS_FOLD_COUNTER $command
-  # actually run command
-  $command || exit 1 # kill build if error
-  travis_time_end moveit_ci$TRAVIS_FOLD_COUNTER
-  #echo -e -n "\e[0Ktravis_fold:end:command$TRAVIS_FOLD_COUNTER\e[0m"
-
-  let "TRAVIS_FOLD_COUNTER += 1"
+  travis_run_impl $@ || exit $?
 }
 
 #######################################
-# Same as travis_run except ignores errors and does not break build
+# Same as travis_run but return 0 exit status, thus ignoring any error
 function travis_run_true() {
-  local command=$@
-
-  travis_time_start moveit_ci$TRAVIS_FOLD_COUNTER $command
-  # actually run command
-  $command # ignore errors
-  travis_time_end moveit_ci$TRAVIS_FOLD_COUNTER
-
-  let "TRAVIS_FOLD_COUNTER += 1"
+  travis_run_impl $@ || return 0
 }
 
 #######################################
-# Orginal version from: https://github.com/travis-ci/travis-build/blob/d63c9e95d6a2dc51ef44d2a1d96d4d15f8640f22/lib/travis/build/script/templates/header.sh
-function my_travis_wait() {
-  local timeout=$1
+# Same as travis_run, but issue some output regularly to indicate that the process is still alive
+# from: https://github.com/travis-ci/travis-build/blob/d63c9e95d6a2dc51ef44d2a1d96d4d15f8640f22/lib/travis/build/script/templates/header.sh
+function travis_run_wait() {
+  local timeout=$1 # in minutes
 
   if [[ $timeout =~ ^[0-9]+$ ]]; then
     # looks like an integer, so we assume it's a timeout
@@ -126,57 +128,46 @@ function my_travis_wait() {
     timeout=20
   fi
 
-  # Show command in console before running
-  echo -e "\e[34m$ $@\e[0m"
+  local cmd=$@
+  let "TRAVIS_FOLD_COUNTER += 1"
+  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $cmd
 
-  my_travis_wait_impl $timeout "$@"
-}
-
-#######################################
-function my_travis_wait_impl() {
-  local timeout=$1
-  shift
-
-  local cmd="$@"
-  local log_file=my_travis_wait_$$.log
-
-  $cmd 2>&1 >$log_file &
+  # Disable bash's job control messages
+  set +m
+  # Run actual command in background
+  $cmd &
   local cmd_pid=$!
 
-  my_travis_jigger $! $timeout $cmd &
+  travis_jigger $cmd_pid $timeout $cmd &
   local jigger_pid=$!
   local result
 
   {
     wait $cmd_pid 2>/dev/null
     result=$?
+    # if process finished before jigger, stop the jigger too
     ps -p$jigger_pid 2>&1>/dev/null && kill $jigger_pid
-  } || return 1
+  }
 
-  echo -e "\nThe command \"$cmd\" exited with $result."
-  #echo -e "\n\033[32;1mLog:\033[0m\n"
-  cat $log_file
+  echo
+  travis_time_end
 
   return $result
 }
 
 #######################################
-function my_travis_jigger() {
-  # helper method for travis_wait()
+function travis_jigger() {
   local cmd_pid=$1
   shift
-  local timeout=$1 # in minutes
+  local timeout=$1
   shift
   local count=0
 
-
-  # clear the line
-  echo -e "\n"
-
+  echo -n "Waiting for process to finish "
   while [ $count -lt $timeout ]; do
     count=$(($count + 1))
-    echo -ne "Still running ($count of $timeout min): $@\r"
-    sleep 60
+    echo -ne "."
+    sleep 60 # wait 60s
   done
 
   echo -e "\n\033[31;1mTimeout (${timeout} minutes) reached. Terminating \"$@\"\033[0m\n"


### PR DESCRIPTION
This PR is actually a merge of several branches (to resolve conflicts).
1. Enabling assertions in Travis build - replacement for #25 
To enable assertions, #25 originally suggested a `Debug` build. However, this unneccessarily slows down the unit tests, thus running out of Travis time. 
My suggestion is to just enable assertions, but keep optimizations.
2. ~~Running clang-format directly within Travis - replacement for #31.~~
The clang-format check doesn't need to be run within a docker container, which is more time-consuming and requires to define variables `ROS_DISTRO` and `ROS_REPO`.
3. General improvements
   - Some fixes to the utility functions in `util.sh`
   - Enable folding and timing for the main build job too.
   - Only run the full MoveIt! build once. All other test cases can be done with an empty `.rosinstall`.
   - rename `my_travis_wait` -> `travis_run_wait`
4. Use xvfb to allow for X11-based unittests - replacement for #1 
5. New attempt to get rid of weird message - replacement for #26 / #32 
`/root/moveit/.moveit_ci/util.sh: line 136: 677 Terminated travis_jigger $! $timeout $cmd`
This message originates from bash's job control and can be suppressed as discussed [here](https://stackoverflow.com/questions/11097761/is-there-a-way-to-make-bash-job-control-quiet).
This works for me locally, **but not in Travis**.

I suggest to manually push-forward the master branch to keep the branch history.