### PR TITLE
make sure container is up to date before building/testing

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -70,6 +70,9 @@ echo "Inside Docker container"
 # Update the sources
 travis_run apt-get -qq update
 
+# Make sure the packages are up-to-date
+travis_run apt-get -qq dist-upgrade
+
 # Split for different tests
 for t in $TEST; do
     case "$t" in


### PR DESCRIPTION
Otherwise ci uses outdated packages and sometimes result in errors like in https://github.com/ros-planning/moveit/pull/827