### PR TITLE
show test logs of failed unittests in Travis

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -185,7 +185,12 @@ travis_run catkin build --no-status --summarize --make-args tests -- ${TEST_PKGS
 # Run non-catkin package tests
 travis_run catkin build --catkin-make-args run_tests -- --no-status --summarize ${TEST_PKGS[@]}
 
-# Show test results and throw error if necessary
+# Show failed tests
+for file in $(catkin_test_results | grep "\.xml:" | cut -d ":" -f1); do
+    travis_run cat $file
+done
+
+# Show test results summary and throw error if necessary
 travis_run catkin_test_results
 
 echo "Travis script has finished successfully"


### PR DESCRIPTION
If there are failing unit tests, we should be able to see more details about the failure.
This addition, shows all logs of failed unittests before giving the final test summary.