### PR TITLE
Allow compiling with different compiler than gcc

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -49,6 +49,8 @@ if ! [ "$IN_DOCKER" ]; then
         -e TRAVIS_BRANCH \
         -e TEST \
         -e TEST_BLACKLIST \
+        -e CC \
+        -e CXX \
         -v $(pwd):/root/$REPOSITORY_NAME \
         -v $HOME/.ccache:/root/.ccache \
         -t \
@@ -67,6 +69,11 @@ fi
 
 # If we are here, we can assume we are inside a Docker container
 echo "Inside Docker container"
+
+# Define CC/CXX defaults and print compiler version info
+export CC=${CC:-cc}
+export CXX=${CXX:-c++}
+$CXX --version
 
 # Update the sources
 travis_run apt-get -qq update

--- a/travis.sh
+++ b/travis.sh
@@ -51,6 +51,8 @@ if ! [ "$IN_DOCKER" ]; then
         -e TEST_BLACKLIST \
         -e CC \
         -e CXX \
+        -e CFLAGS \
+        -e CXXFLAGS \
         -v $(pwd):/root/$REPOSITORY_NAME \
         -v $HOME/.ccache:/root/.ccache \
         -t \


### PR DESCRIPTION
Passing env variables CC and CXX to the docker container, it becomes possible to specify the
compiler in Travis. Additionally print info about the used compiler.
This goes along with https://github.com/ros-planning/moveit/pull/1201, which installs clang in the docker container.

I also added passing of CFLAGS and CXXFLAGS variables to allow for configuration of compiler warnings.

Note that the Travis build fails with an unrelated test, which is broken for a while already.