### PR TITLE
clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,17 @@
+---
+Checks:          '-*,
+                  clang-analyzer-*,
+                  performance-*,
+                  modernize-redundant-void-arg,
+                  modernize-use-nullptr,
+                  modernize-use-default,
+                  modernize-use-override,
+                  readability-named-parameter,
+                  readability-redundant-smartptr-get,
+                  readability-redundant-string-cstr,
+                  readability-simplify-boolean-expr,
+                  readability-container-size-empty,
+                  '
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,14 @@ notifications:
        - dave@dav.ee
 env:
   matrix:
+    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-format
+    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=clang-tidy.rosinstall
+    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=clang-tidy.rosinstall
+
     - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format
+    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=clang-tidy.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=clang-tidy.rosinstall
+
     - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed

--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ More configurations as seen in [industrial_ci](https://github.com/ros-industrial
 
 ## Clang-Format
 
-A new test is available that checks if the code is properly formatted as specified in the clang-format file found in ``.clang-format``. Use ``TEST=clang-format`` to enable this test.
+Clang-format allows to validate that the source code is properly formatted according to a specification provided in ``.clang-format`` files in the folder hierarchy.
+Use ``TEST=clang-format`` to enable this test.
+
+## Clang-Tidy
+
+Clang-tidy allows for static code analysis and validation of naming rules.
+Use ``TEST=clang-tidy-check`` to enable clang-tidy analysis, but only issuing warnings.
+Use ``TEST=clang-tidy-fix`` to reject code that doesn't comply to the rules.
 
 ## Running Locally For Testing
 

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -1,0 +1,29 @@
+# Change to source directory.
+pushd $CI_SOURCE_PATH
+
+# This directory can have its own .clang-tidy config file but if not, MoveIt's will be provided
+if [ ! -f .clang-tidy ]; then
+    wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-tidy"
+fi
+
+# Find run-clang-tidy script: Xenial and Bionic install them with different names
+export RUN_CLANG_TIDY=$(ls -1 /usr/bin/run-clang-tidy* | head -1)
+
+# Run clang-tidy in all build folders containing a compile_commands.json file
+# Pipe the very verbose output of clang-tidy to /dev/null
+echo "Running clang-tidy"
+travis_run_wait 60 find $CATKIN_WS/build -name compile_commands.json -exec \
+    sh -c 'echo "Processing $(basename $(dirname {}))"; $RUN_CLANG_TIDY -fix -format -p $(dirname {}) > /dev/null' \;
+
+echo "Showing changes in code:"
+git --no-pager diff
+
+# Make sure no changes have occured in repo
+if ! git diff-index --quiet HEAD --; then
+    # changes
+    echo "clang-tidy test failed: changes required to comply to rules. See diff above."
+    exit 1
+fi
+
+echo "Passed clang-tidy check"
+popd

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -13,6 +13,8 @@ export RUN_CLANG_TIDY=$(ls -1 /usr/bin/run-clang-tidy* | head -1)
 # Pipe the very verbose output of clang-tidy to /dev/null
 echo "Running clang-tidy"
 
+ls $CATKIN_WS/build
+find $CATKIN_WS/build -name compile_commands.json
 travis_run_wait 60 find $CATKIN_WS/build -name compile_commands.json -exec \
     sh -c 'echo "Processing $(basename $(dirname {}))"; $RUN_CLANG_TIDY -fix -format -p $(dirname {}) > /dev/null 2>&1' \;
 

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -12,8 +12,9 @@ export RUN_CLANG_TIDY=$(ls -1 /usr/bin/run-clang-tidy* | head -1)
 # Run clang-tidy in all build folders containing a compile_commands.json file
 # Pipe the very verbose output of clang-tidy to /dev/null
 echo "Running clang-tidy"
+
 travis_run_wait 60 find $CATKIN_WS/build -name compile_commands.json -exec \
-    sh -c 'echo "Processing $(basename $(dirname {}))"; $RUN_CLANG_TIDY -fix -format -p $(dirname {}) > /dev/null' \;
+    sh -c 'echo "Processing $(basename $(dirname {}))"; $RUN_CLANG_TIDY -fix -format -p $(dirname {}) > /dev/null 2>&1' \;
 
 echo "Showing changes in code:"
 git --no-pager diff

--- a/clang-tidy.rosinstall
+++ b/clang-tidy.rosinstall
@@ -1,0 +1,5 @@
+# This file is intended for testing clang-tidy in moveit_ci on travis
+- git:
+    local-name: geometric_shapes
+    uri: https://github.com/ros-planning/geometric_shapes.git
+    version: melodic-devel


### PR DESCRIPTION
Implements two clang-tidy checks:
- clang-tidy-check: Only issues warnings during compilation
- clang-tidy-fix: Report an error if there are applicable clang-tidy fixes

Addresses #12.