### PR TITLE
several fixes to the travis CI scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=clang-tidy.rosinstall
     - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=clang-tidy.rosinstall
 
-    - ROS_DISTRO=kinetic ROS_REPO=ros              UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'" TEST_BLACKLIST="moveit_core"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed UPSTREAM_WORKSPACE=travis.rosinstall BEFORE_SCRIPT="echo 'testing'"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed
+    # Test BEFORE_SCRIPT and ros vs. ros-shadow-fixed
+    - ROS_DISTRO=kinetic ROS_REPO=ros              BEFORE_SCRIPT="echo first && false; echo second > /dev/null; echo Testing on $ROS_DISTRO"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT="wget -nv www.google.com"
+
       TEST_BLACKLIST=moveit,moveit_ros,moveit_runtime,moveit_ros_perception
       UPSTREAM_WORKSPACE="https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,
                           https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ env:
                           # Duplicated rosinstall file for testing purposes
 
 before_script:
-  - ln -s . .moveit_ci # pretend to have the usual location
+  - ln -s . .moveit_ci  # pretend to have the usual location
+  - ./unittest.sh  # unittests for travis' utility functions
 
 script:
   - .moveit_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,13 @@ notifications:
        - dave@dav.ee
 env:
   matrix:
-    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-format
-    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=clang-tidy.rosinstall
-    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=clang-tidy.rosinstall
+    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-format                    UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=travis.rosinstall
 
-    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format
-    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=clang-tidy.rosinstall
-    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=clang-tidy.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format                    UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=travis.rosinstall
 
     # Test BEFORE_SCRIPT and ros vs. ros-shadow-fixed
     - ROS_DISTRO=kinetic ROS_REPO=ros              BEFORE_SCRIPT="echo first && false; echo second > /dev/null; echo Testing on $ROS_DISTRO"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,11 @@ env:
     - ROS_DISTRO=kinetic ROS_REPO=ros              BEFORE_SCRIPT="echo first && false; echo second > /dev/null; echo Testing on $ROS_DISTRO"
     - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT="wget -nv www.google.com"
 
+    # Build MoveIt repo
+    - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed TEST="clang-tidy-check clang-tidy-fix"
       TEST_BLACKLIST=moveit,moveit_ros,moveit_runtime,moveit_ros_perception
-      UPSTREAM_WORKSPACE="https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall,
-                          https://raw.githubusercontent.com/ros-planning/moveit/kinetic-devel/moveit.rosinstall"
+      UPSTREAM_WORKSPACE="https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall,
+                          https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall"
                           # Duplicated rosinstall file for testing purposes
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,18 @@ notifications:
        - dave@dav.ee
 env:
   matrix:
-    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-format                    UPSTREAM_WORKSPACE=travis.rosinstall
-    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=travis.rosinstall
-    - ROS_DISTRO=melodic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=melodic ROS_REPO=ros   TEST=clang-format                        UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=melodic ROS_REPO=ros   TEST="clang-tidy-check clang-tidy-fix"   UPSTREAM_WORKSPACE=travis.rosinstall
 
-    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-format                    UPSTREAM_WORKSPACE=travis.rosinstall
-    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-check                UPSTREAM_WORKSPACE=travis.rosinstall
-    - ROS_DISTRO=kinetic ROS_REPO=ros              TEST=clang-tidy-fix                  UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros   TEST=clang-format                        UPSTREAM_WORKSPACE=travis.rosinstall
+    - ROS_DISTRO=kinetic ROS_REPO=ros   TEST="clang-tidy-check clang-tidy-fix"   UPSTREAM_WORKSPACE=travis.rosinstall
 
     # Test BEFORE_SCRIPT and ros vs. ros-shadow-fixed
     - ROS_DISTRO=kinetic ROS_REPO=ros              BEFORE_SCRIPT="echo first && false; echo second > /dev/null; echo Testing on $ROS_DISTRO"
-    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT="wget -nv www.google.com"
+    - ROS_DISTRO=kinetic ROS_REPO=ros-shadow-fixed BEFORE_DOCKER_SCRIPT="wget -nv www.google.com; exit 0"
 
     # Build MoveIt repo
-    - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed TEST="clang-tidy-check clang-tidy-fix"
+    - ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed TEST=clang-tidy-fix
       TEST_BLACKLIST=moveit,moveit_ros,moveit_runtime,moveit_ros_perception
       UPSTREAM_WORKSPACE="https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall,
                           https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall"

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ script:
 
 - ROS_DISTRO: (required) which version of ROS i.e. kinetic
 - ROS_REPO: (default: ros-shadow-fixed) install ROS debians from either regular release or from shadow-fixed, i.e. http://packages.ros.org/ros-shadow-fixed/ubuntu
-- BEFORE_DOCKER_SCRIPT: (default: not set): Used to specify a shell command or script that runs before starting the docker container. This is similar to Travis' before_script section, but having a variable allows to selectively switch scripts within the testing matrix.
-- BEFORE_SCRIPT: (default: not set): Used to specify a shell command or script that runs in docker before building packages. In contrast to BEFORE_DOCKER_SCRIPT, this script runs in the context of the docker container.
+- BEFORE_DOCKER_SCRIPT: (default: not set): Used to specify shell commands or scripts that run before starting the docker container. This is similar to Travis' before_script section, but having a variable allows to selectively switch scripts within the testing matrix.
+- BEFORE_SCRIPT: (default: not set): Used to specify shell commands or scripts that run in docker before building packages. In contrast to BEFORE_DOCKER_SCRIPT, this script runs in the context of the docker container.
 - UPSTREAM_WORKSPACE (default: debian): When set as "file", the dependended packages that need to be built from source are downloaded based on a .rosinstall file in your repository. When set to a "http" URL, this downloads the rosinstall configuration from an http location. Multiple http entries can be given by separating each by comma, but the order of the entries matters -- if there's same resource defined in multiple entries, the one that appears the first is used.
 - TEST_BLACKLIST: Allow certain tests to be skipped if necessary (not recommended)
 - TEST: allow other tests to be run, such as code format checking using clang-format

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -2,8 +2,7 @@
 travis_run apt-get -qq install -y clang-format-3.9
 
 # Change to source directory.
-travis_run cd $CI_SOURCE_PATH
-travis_run ls -la
+cd $CI_SOURCE_PATH
 
 # This directory can have its own .clang-format config file but if not, MoveIt's will be provided
 if [ ! -f .clang-format ]; then
@@ -11,17 +10,16 @@ if [ ! -f .clang-format ]; then
 fi
 
 # Run clang-format
-echo "Running clang-format"
+travis_time_start moveit_ci.clang-format "Running clang-format"  # start fold
 find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-3.9 -i -style=file
-
-echo "Showing changes in code style:"
-git --no-pager diff
+travis_time_end  # end fold
 
 # Make sure no changes have occured in repo
 if ! git diff-index --quiet HEAD --; then
     # changes
-    echo "clang-format test failed: changes required to comply to formatting rules. See diff above.";
+    echo -e "\033[31;1mclang-format test failed: The following changes are required to comply to rules:\033[0m"
+    git --no-pager diff
     exit 1 # error
 fi
 
-echo "Passed clang-format test"
+echo -e "\033[32;1mPassed clang-format check\033[0m"

--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -7,7 +7,7 @@ travis_run ls -la
 
 # This directory can have its own .clang-format config file but if not, MoveIt's will be provided
 if [ ! -f .clang-format ]; then
-    wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-format"
+    travis_run wget -nv "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-format"
 fi
 
 # Run clang-format

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -3,7 +3,7 @@ pushd $CI_SOURCE_PATH
 
 # This directory can have its own .clang-tidy config file but if not, MoveIt's will be provided
 if [ ! -f .clang-tidy ]; then
-    wget "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-tidy"
+    travis_run wget -nv "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-tidy"
 fi
 
 # Find run-clang-tidy script: Xenial and Bionic install them with different names

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -25,8 +25,9 @@ COUNTER=0
 ) &
 cmd_pid=$!  # main cmd PID
 
+timeout=$(( $TRAVIS_GLOBAL_TIMEOUT - ($(date +%s) - $TRAVIS_GLOBAL_START_TIME) / 60 ))
 # Use travis_jigger to generate some '.' outputs to convince Travis, we are not stuck.
-travis_jigger $cmd_pid 10 "clang-tidy" &
+travis_jigger $cmd_pid $timeout "clang-tidy" &
 jigger_pid=$!
 
 # Wait for main command to finish

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -1,32 +1,42 @@
 # Change to source directory.
-pushd $CI_SOURCE_PATH
-
-# This directory can have its own .clang-tidy config file but if not, MoveIt's will be provided
-if [ ! -f .clang-tidy ]; then
-    travis_run wget -nv "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-tidy"
-fi
+pushd $CI_SOURCE_PATH > /dev/null
 
 # Find run-clang-tidy script: Xenial and Bionic install them with different names
 export RUN_CLANG_TIDY=$(ls -1 /usr/bin/run-clang-tidy* | head -1)
 
+
 # Run clang-tidy in all build folders containing a compile_commands.json file
 # Pipe the very verbose output of clang-tidy to /dev/null
-echo "Running clang-tidy"
+# Use travis_jigger to generate some '.' outputs to convince Travis, we are not stuck.
+echo -e "\033[33;1mRunning clang-tidy check\033[0m"
+COUNTER=0
+(
+	for file in $(find $CATKIN_WS/build -name compile_commands.json) ; do
+		let "COUNTER += 1"
+		travis_time_start clang-tidy.$COUNTER "Processing $(basename $(dirname $file))"
+		$RUN_CLANG_TIDY -fix -p $(dirname $file) > /dev/null 2>&1
+		travis_time_end
+	done
+) &
+cmd_pid=$!  # main cmd PID
 
-ls $CATKIN_WS/build
-find $CATKIN_WS/build -name compile_commands.json
-travis_run_wait 60 find $CATKIN_WS/build -name compile_commands.json -exec \
-    sh -c 'echo "Processing $(basename $(dirname {}))"; $RUN_CLANG_TIDY -fix -format -p $(dirname {}) > /dev/null 2>&1' \;
+# Start jigger process, taking care of the timeout and '.' outputs
+travis_jigger $cmd_pid 10 "clang-tidy" &
+jigger_pid=$!
 
-echo "Showing changes in code:"
-git --no-pager diff
+# Wait for main command to finish
+wait $cmd_pid 2>/dev/null
+# Stop travis_jigger in any case
+kill $jigger_pid 2> /dev/null && wait $! 2> /dev/null
+
 
 # Make sure no changes have occured in repo
 if ! git diff-index --quiet HEAD --; then
     # changes
-    echo "clang-tidy test failed: changes required to comply to rules. See diff above."
+    echo -e "\033[31;1mclang-tidy test failed: The following changes are required to comply to rules:\033[0m"
+    git --no-pager diff
     exit 1
 fi
 
-echo "Passed clang-tidy check"
-popd
+echo -e "\033[32;1mPassed clang-tidy check\033[0m"
+popd > /dev/null

--- a/clang-tidy.rosinstall
+++ b/clang-tidy.rosinstall
@@ -1,5 +1,0 @@
-# This file is intended for testing clang-tidy in moveit_ci on travis
-- git:
-    local-name: geometric_shapes
-    uri: https://github.com/ros-planning/geometric_shapes.git
-    version: melodic-devel

--- a/travis.rosinstall
+++ b/travis.rosinstall
@@ -1,1 +1,6 @@
 # This file is intended for testing moveit_ci on travis
+# It should only list a very few, fast-to-build repositories
+- git:
+    local-name: geometric_shapes
+    uri: https://github.com/ros-planning/geometric_shapes.git
+    version: melodic-devel

--- a/travis.sh
+++ b/travis.sh
@@ -25,7 +25,7 @@ source ${CI_SOURCE_PATH}/$CI_PARENT_DIR/util.sh
 if ! [ "$IN_DOCKER" ]; then
     # Run BEFORE_DOCKER_SCRIPT
     if [ "${BEFORE_DOCKER_SCRIPT// }" != "" ]; then
-        travis_run sh -c "${BEFORE_DOCKER_SCRIPT}"
+        travis_run $BEFORE_DOCKER_SCRIPT
     fi
 
     # Choose the correct CI container to use
@@ -178,7 +178,7 @@ travis_run ls -a
 
 # Run BEFORE_SCRIPT
 if [ "${BEFORE_SCRIPT// }" != "" ]; then
-    travis_run sh -c "${BEFORE_SCRIPT}";
+    travis_run $BEFORE_SCRIPT
 fi
 
 # Install source-based package dependencies

--- a/travis.sh
+++ b/travis.sh
@@ -14,6 +14,8 @@ export CI_SOURCE_PATH=$(pwd) # The repository code in this pull request that we 
 export CI_PARENT_DIR=.moveit_ci  # This is the folder name that is used in downstream repositories in order to point to this repo.
 export REPOSITORY_NAME=${PWD##*/}
 export CATKIN_WS=/root/ws_moveit
+export TRAVIS_GLOBAL_TIMEOUT=45  # 50min minus slack
+export TRAVIS_GLOBAL_START_TIME=$(date +%s)
 echo "---"
 echo "\033[33;1mTesting branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'\033[0m"
 

--- a/travis.sh
+++ b/travis.sh
@@ -219,10 +219,10 @@ if [ -n "$TEST_PKGS" ]; then
     TEST_PKGS="--no-deps ${TEST_PKGS[@]}"
 
     # Run catkin package tests
-    travis_run catkin build --no-status --summarize --make-args tests -- $TEST_PKGS
+    travis_run_wait catkin build --no-status --summarize --make-args tests -- $TEST_PKGS
 
     # Run non-catkin package tests
-    travis_run catkin build --catkin-make-args run_tests -- --no-status --summarize $TEST_PKGS
+    travis_run_wait catkin build --catkin-make-args run_tests -- --no-status --summarize $TEST_PKGS
 
     # Show failed tests
     for file in $(catkin_test_results | grep "\.xml:" | cut -d ":" -f1); do

--- a/travis.sh
+++ b/travis.sh
@@ -113,6 +113,12 @@ for t in $TEST; do
             ;;
     esac
 done
+if [[ "$TEST" == *clang-tidy* ]] ; then
+    # Provide a default .clang-tidy config file from MoveIt as a fallback for the whole workspace
+    # Files within specific package repositories take precedence of this.
+    travis_run wget -nv https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-tidy -O $CATKIN_WS/.clang-tidy
+    travis_run cat $CATKIN_WS/.clang-tidy
+fi
 
 # Enable ccache
 travis_run apt-get -qq install ccache

--- a/unittest.sh
+++ b/unittest.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+source util.sh
+
+# save stdout as 3 and stderr as 4, then redirect stdout(1) to /dev/null and stderr(2) to 3(stdout)
+exec 3>&1  4>&2  1>/dev/null  2>&3
+
+function EXPECT_TRUE {
+	local test_cmd=$1
+	local location=$2
+	local message=$3
+	if ! eval $test_cmd ; then
+		exec 1>&3  2>&4  # restore stdout + stderr
+		echo -e "$location:\033[31;1m $test_cmd \033[0m $message"
+		exit -1
+	fi
+}
+
+# travis_run_impl should return the value of the (last) command
+travis_run_impl true
+EXPECT_TRUE "test $? -eq 0" $0:$LINENO "Wrong result"
+
+travis_run_impl false
+EXPECT_TRUE "test $? -eq 1" $0:$LINENO "Wrong result"
+
+travis_run_impl return 2
+EXPECT_TRUE "test $? -eq 2" $0:$LINENO "Wrong result"
+
+# several commands should be possible too, e.g. when passed into BEFORE_SCRIPT variable
+cmds="echo; return 2"
+travis_run_impl $cmds
+EXPECT_TRUE "test $? -eq 2" $0:$LINENO "Wrong result"
+
+
+# travis_run should continue on success
+travis_run true
+EXPECT_TRUE "test $? -eq 0" $0:$LINENO "Wrong result"
+
+# ... but exit on failure
+(travis_run false)  # run in subshell to avoid exit from this script
+EXPECT_TRUE "test $? -eq 1" $0:$LINENO "Wrong result"
+
+
+# travis_run_wait should continue on success
+travis_run_wait 10 true
+EXPECT_TRUE "test $? -eq 0" $0:$LINENO "Wrong result"
+
+# ... but exit on failure
+(travis_run_wait 10 false)  # run in subshell to avoid exit from this script
+EXPECT_TRUE "test $? -eq 1" $0:$LINENO "Wrong result"
+
+
+# first (numerical) argument to travis_run_wait is optional
+travis_run_wait true
+EXPECT_TRUE "test $? -eq 0" $0:$LINENO "Wrong result"
+
+(travis_run_wait false)  # run in subshell to avoid exit from this script
+EXPECT_TRUE "test $? -eq 1" $0:$LINENO "Wrong result"
+
+
+exec 1>&3  2>&4  # restore stdout + stderr
+echo -e "\033[32;1mSuccessfully passed unittest\033[0m"

--- a/util.sh
+++ b/util.sh
@@ -86,8 +86,8 @@ function travis_time_end {
 #######################################
 # Display command in Travis console and fold output in dropdown section
 #
-# Arguments:
-#   command: action to run
+# Arguments: commands to run
+# Return: exit status of the command
 #######################################
 function travis_run_impl() {
   local commands=$@
@@ -102,16 +102,15 @@ function travis_run_impl() {
 }
 
 #######################################
-# Run a command and do folding and timing for it
-#   Return the exit status of the command
+# Run passed commands and exit if the last one fails
 function travis_run() {
   travis_run_impl $@ || exit $?
 }
 
 #######################################
-# Same as travis_run but return 0 exit status, thus ignoring any error
+# Same as travis_run but ignore any error
 function travis_run_true() {
-  travis_run_impl $@ || return 0
+  travis_run_impl $@ || true
 }
 
 #######################################
@@ -152,7 +151,7 @@ function travis_run_wait() {
   echo
   travis_time_end
 
-  return $result
+  test $result -eq 0 || exit $result
 }
 
 #######################################

--- a/util.sh
+++ b/util.sh
@@ -90,12 +90,12 @@ function travis_time_end {
 #   command: action to run
 #######################################
 function travis_run_impl() {
-  local command=$@
+  local commands=$@
 
   let "TRAVIS_FOLD_COUNTER += 1"
-  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $command
-  # actually run command
-  $command
+  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $commands
+  # actually run commands, eval needed to handle multiple commands!
+  eval $commands
   result=$?
   travis_time_end
   return $result
@@ -128,17 +128,17 @@ function travis_run_wait() {
     timeout=20
   fi
 
-  local cmd=$@
+  local commands=$@
   let "TRAVIS_FOLD_COUNTER += 1"
-  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $cmd
+  travis_time_start moveit_ci.$TRAVIS_FOLD_COUNTER $commands
 
   # Disable bash's job control messages
   set +m
-  # Run actual command in background
-  $cmd &
+  # actually run commands, eval needed to handle multiple commands!
+  eval $commands &
   local cmd_pid=$!
 
-  travis_jigger $cmd_pid $timeout $cmd &
+  travis_jigger $cmd_pid $timeout $commands &
   local jigger_pid=$!
   local result
 

--- a/util.sh
+++ b/util.sh
@@ -138,16 +138,16 @@ function travis_run_wait() {
   eval $commands &
   local cmd_pid=$!
 
+  # Start jigger process, taking care of the timeout and '.' outputs
   travis_jigger $cmd_pid $timeout $commands &
   local jigger_pid=$!
-  local result
 
-  {
-    wait $cmd_pid 2>/dev/null
-    result=$?
-    # if process finished before jigger, stop the jigger too
-    ps -p$jigger_pid 2>&1>/dev/null && kill $jigger_pid
-  }
+  # Wait for main command to finish
+  wait $cmd_pid 2>/dev/null
+  local result=$?
+  # If main process finished before jigger, stop the jigger too
+  # https://stackoverflow.com/questions/81520/how-to-suppress-terminated-message-after-killing-in-bash
+  kill $jigger_pid 2> /dev/null && wait $! 2> /dev/null
 
   echo
   travis_time_end

--- a/util.sh
+++ b/util.sh
@@ -163,11 +163,10 @@ function travis_jigger() {
   shift
   local count=0
 
-  echo -n "Waiting for process to finish "
   while [ $count -lt $timeout ]; do
     count=$(($count + 1))
-    echo -ne "."
     sleep 60 # wait 60s
+    echo -ne "."
   done
 
   echo -e "\n\033[31;1mTimeout (${timeout} minutes) reached. Terminating \"$@\"\033[0m\n"


### PR DESCRIPTION
This PR fixes several issues (including some basic ones) such that #42 and #43 actually work.
First of all, BEFORE_SCRIPTS didn't run correctly for a while. For example [here](https://travis-ci.org/ros-planning/moveit_ci/jobs/466795365#L1494) `testing` should be printed, but it's not. I fixed this, by `evaluating` commands passed to `travis_run_*` and I added some "bash unittests" to validate this.

Getting clang-tidy running wasn't trivial as well, getting .clang-tidy into the correct location and convincing travis to not bail out.

All the other commits are small, independent and self-explanatory changes, which is why this PR should be merge-committed as discussed in https://github.com/ros-planning/moveit_tutorials/issues/280#issuecomment-457203768 ;-)