### PR TITLE
fix minor issues

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -9,7 +9,7 @@
 #
 # Author:  Dave Coleman, Isaac I. Y. Saito, Robert Haschke
 
-export MOVEIT_CI_DIR=$(dirname $0)  # path to the directory running the current script
+export MOVEIT_CI_DIR=$(dirname ${BASH_SOURCE:-$0})  # path to the directory running the current script
 export REPOSITORY_NAME=$(basename $PWD) # name of repository, travis originally checked out
 export CATKIN_WS=${CATKIN_WS:-/root/ws_moveit} # location of catkin workspace
 

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -98,7 +98,7 @@ for group in $test_groups ; do
 			;;
 		warnings)
 			run_test 0 $0:$LINENO "'warnings' package with warnings allowed" TEST_PKG=warnings WARNINGS_OK=true
-			run_test 2 $0:$LINENO "'warnings' package with warnings forbidden" TEST_PKG=warnings WARNINGS_OK=false
+			run_test 1 $0:$LINENO "'warnings' package with warnings forbidden" TEST_PKG=warnings WARNINGS_OK=false
 			run_test 0 $0:$LINENO "'valid' package with warnings forbidden" TEST_PKG=valid WARNINGS_OK=false
 			;;
 		catkin_lint)
@@ -114,11 +114,11 @@ for group in $test_groups ; do
 			;;
 		clang-tidy-fix)
 			run_test 0 $0:$LINENO "clang-tidy-fix on 'valid' package" TEST_PKG=valid TEST=clang-tidy-fix
-			run_test 2 $0:$LINENO "clang-tidy-fix on 'clang_tidy' package" TEST_PKG=clang_tidy TEST=clang-tidy-fix
+			run_test 1 $0:$LINENO "clang-tidy-fix on 'clang_tidy' package" TEST_PKG=clang_tidy TEST=clang-tidy-fix
 			;;
 		clang-tidy-check)  # only supported for cmake >= 3.6
 			run_test 0 $0:$LINENO "clang-tidy-check on 'valid' package, warnings forbidden" TEST_PKG=valid TEST=clang-tidy-check WARNINGS_OK=false
-			run_test 2 $0:$LINENO "clang-tidy-check on 'clang_tidy' package, warnings forbidden" TEST_PKG=clang_tidy TEST=clang-tidy-check WARNINGS_OK=false
+			run_test 1 $0:$LINENO "clang-tidy-check on 'clang_tidy' package, warnings forbidden" TEST_PKG=clang_tidy TEST=clang-tidy-check WARNINGS_OK=false
 			;;
 		*) echo -e $(colorize YELLOW "Unknown test group '$group'.")
 			echo "Known groups are: $all_groups" ;;


### PR DESCRIPTION
- compute correct MOVEIT_CI_DIR, also when travis.sh is sourced and not run
- enable multiple clang-tidy checks
- run all final checks and don't bail out on first failing one