### PR TITLE
Use latest version of catkin_lint

### DIFF
--- a/check_catkin_lint.sh
+++ b/check_catkin_lint.sh
@@ -4,6 +4,8 @@
 # Desc: Check for warnings during build process of repo $CI_SOURCE_PATH
 
 travis_fold start check.catkin_lint "Checking for issues reported by catkin_lint"
+
+travis_run catkin_lint --version
 travis_run --title "Running catkin_lint in repository source: $CI_SOURCE_PATH" \
     catkin_lint $CI_SOURCE_PATH
 result=$?

--- a/check_catkin_lint.sh
+++ b/check_catkin_lint.sh
@@ -4,8 +4,6 @@
 # Desc: Check for warnings during build process of repo $CI_SOURCE_PATH
 
 travis_fold start check.catkin_lint "Checking for issues reported by catkin_lint"
-
-travis_run apt-get -qq install -y python-catkin-lint
 travis_run --title "Running catkin_lint in repository source: $CI_SOURCE_PATH" \
     catkin_lint $CI_SOURCE_PATH
 result=$?

--- a/travis.sh
+++ b/travis.sh
@@ -93,7 +93,13 @@ function update_system() {
    [ "$TEST" == *clang-tidy-fix* ] && travis_run_true apt-get -qq install -y clang-tools
    # Install abi-compliance-checker if needed
    [[ "$TEST" == *abi* ]] && travis_run_true apt-get -qq install -y abi-dumper abi-compliance-checker links
-
+   # Install catkin_lint if needed
+   if [[ "$TEST" == *catkin_lint* ]]
+   then
+       travis_run apt-get -qq install -y python-pip
+       travis_run pip install catkin_lint
+       travis_run catkin_lint --version
+   fi
    # Enable ccache
    travis_run apt-get -qq install ccache
    export PATH=/usr/lib/ccache:$PATH
@@ -273,7 +279,7 @@ function test_workspace() {
 
 ###########################################################################################################
 # main program
- 
+
 # This repository has some dummy catkin packages in folder test_pkgs, which are needed for unit testing only.
 # To not clutter normal builds, we just create a CATKIN_IGNORE file in that folder.
 # A unit test can be recognized from the presence of the environment variable $TEST_PKG (see unit_tests.sh)

--- a/travis.sh
+++ b/travis.sh
@@ -94,11 +94,9 @@ function update_system() {
    # Install abi-compliance-checker if needed
    [[ "$TEST" == *abi* ]] && travis_run_true apt-get -qq install -y abi-dumper abi-compliance-checker links
    # Install catkin_lint if needed
-   if [[ "$TEST" == *catkin_lint* ]]
-   then
+   if [[ "$TEST" == *catkin_lint* ]]; then
        travis_run apt-get -qq install -y python-pip
        travis_run pip install catkin_lint
-       travis_run catkin_lint --version
    fi
    # Enable ccache
    travis_run apt-get -qq install ccache


### PR DESCRIPTION
Since catkin_lint in the ROS Package archives only gets updated once in
a while, ~~use the PPA with the latest release (if available)~~ install catkin_lint from PyPI with PIP.
