### PR TITLE
Adapt moveit_ci for moveit2 development

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ First clone the repo you want to test:
 
 Next clone the CI script:
 
-    git clone -b ros2 https://github.com/ros-planning/moveit_ci .moveit_ci
+    git clone -b ros2 https://github.com/acutronicrobotics/moveit_ci .moveit_ci
 
 Manually define the variables, Travis would otherwise define for you. These are required:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Manually define the variables, Travis would otherwise define for you. These are 
 
     export TRAVIS_BRANCH=master
     export ROS_DISTRO=crystal
-    export ROS_REPO=ros
+    export ROS_REPO=acutronicrobotics
     export CC=gcc
     export CXX=g++
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ It's also possible to run the moveit\_ci script locally, without Travis. We demo
 First clone the repo you want to test:
 
     cd /tmp/travis   # any working directory will do
-    git clone https://github.com/ros-planning/moveit2
+    git clone https://github.com/acutronicrobotics/moveit2
     cd moveit2
 
 Next clone the CI script:
@@ -141,3 +141,25 @@ It's also possible to run the script without using docker. To this end, issue th
     mkdir $ROS_WS                    # and create it
 
     .moveit_ci/travis.sh
+
+## Running Locally For Testing in `OS X`
+
+First clone the repo you want to test:
+
+    cd /tmp/travis   # any working directory will do
+    git clone https://github.com/acutronicrobotics/moveit2
+    cd moveit2
+
+Next clone the CI script:
+
+    git clone -b ros2 https://github.com/acutronicrobotics/moveit_ci .moveit_ci
+
+Manually define the variables, Travis would otherwise define for you. These are required:
+
+    export TRAVIS_BRANCH=master
+    export ROS_DISTRO=crystal
+    export ROS_REPO=acutronicrobotics
+    export CC=gcc
+    export CXX=g++
+    export UPSTREAM_WORKSPACE=moveit.rosinstall
+    export TRAVIS_OS_NAME=osx

--- a/README.md
+++ b/README.md
@@ -163,3 +163,6 @@ Manually define the variables, Travis would otherwise define for you. These are 
     export CXX=g++
     export UPSTREAM_WORKSPACE=moveit.rosinstall
     export TRAVIS_OS_NAME=osx
+Start the script
+
+    .moveit_ci/travis.sh

--- a/travis.sh
+++ b/travis.sh
@@ -263,8 +263,7 @@ function build_workspace() {
    travis_run_simple touch src/image_common/camera_info_manager/COLCON_IGNORE
 
    # For a command that doesn’t produce output for more than 10 minutes, prefix it with travis_run_wait
-   COLCON_CMAKE_ARGS="--cmake-args $CMAKE_ARGS --catkin-cmake-args $CMAKE_ARGS --ament-cmake-args $CMAKE_ARGS"
-   travis_run_wait 60 --title "colcon build" colcon build $COLCON_CMAKE_ARGS $COLCON_EVENT_HANDLING
+   travis_run_wait 60 --title "colcon build" colcon build --merge-install $COLCON_CMAKE_ARGS $COLCON_EVENT_HANDLING
 
    # Allow to verify ccache usage
    travis_run --title "ccache statistics" ccache -s

--- a/travis.sh
+++ b/travis.sh
@@ -97,8 +97,8 @@ function update_system() {
    # Make sure the packages are up-to-date
    travis_run apt-get -qq dist-upgrade
 
-   # Make sure autoconf is installed
-   travis_run apt-get -qq install -y autoconf
+   # Make sure autoconf is installed and python3-lxml for the tests
+   travis_run apt-get -qq install -y autoconf python3-lxml
 
    # Install clang-tidy stuff if needed
    [[ "$TEST" == *clang-tidy* ]] && travis_run apt-get -qq install -y clang-tidy

--- a/travis.sh
+++ b/travis.sh
@@ -217,7 +217,7 @@ function prepare_ros_workspace() {
    travis_run --title "List files in ROS workspace's source folder" ls --color=auto -alhF
 
    # Install source-based package dependencies
-   travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO
+   travis_run_true rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO
 
    # Change to base of workspace
    travis_run_simple cd $ROS_WS

--- a/travis.sh
+++ b/travis.sh
@@ -283,7 +283,7 @@ function test_workspace() {
    blacklist_pkgs=$(filter_out "$source_pkgs" "$all_pkgs")
 
    # Run tests, suppressing the error output (confuses Travis display?)
-   travis_run_wait --title "colcon test" "colcon test --packages-skip $TEST_BLACKLIST $blacklist $COLCON_EVENT_HANDLING 2>/dev/null"
+   travis_run_wait --title "colcon test" "colcon test --packages-skip $TEST_BLACKLIST $blacklist $COLCON_EVENT_HANDLING --merge-install 2>/dev/null"
 
    # Show failed tests
    travis_fold start test.results "colcon test-results"

--- a/travis.sh
+++ b/travis.sh
@@ -238,7 +238,7 @@ function prepare_ros_workspace() {
    travis_run --title "List files in ROS workspace's source folder" ls --color=auto -alhF
 
    # Install source-based package dependencies
-   travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO
+   travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO --skip-keys moveit_msgs octomap_msgs object_recognition_msgs
 
    # Change to base of workspace
    travis_run_simple cd $ROS_WS

--- a/travis.sh
+++ b/travis.sh
@@ -259,8 +259,8 @@ function build_workspace() {
 
    # COLCON_IGNORE packages that cause the build to fail
    # TODO: review this
-   travis_run_simple touch src/image_common/camera_calibration_parsers/COLCON_IGNORE
-   travis_run_simple touch src/image_common/camera_info_manager/COLCON_IGNORE
+   travis_run_simple touch $ROS_WS/src/image_common/camera_calibration_parsers/COLCON_IGNORE
+   travis_run_simple touch $ROS_WS/src/image_common/camera_info_manager/COLCON_IGNORE
 
    # For a command that doesn’t produce output for more than 10 minutes, prefix it with travis_run_wait
    travis_run_wait 60 --title "colcon build" colcon build --merge-install $COLCON_CMAKE_ARGS $COLCON_EVENT_HANDLING

--- a/travis.sh
+++ b/travis.sh
@@ -167,9 +167,9 @@ function prepare_ros_workspace() {
 
    if [[ "${ROS_REPO}" == acutronicrobotics ]]; then
      travis_run_simple cd $ROS_WS
-     # There's already a moveit2.repos locally, no need to fetch it
-     # travis_run wget https://raw.githubusercontent.com/AcutronicRobotics/moveit2/master/moveit2.repos
-     travis_run vcs import src < moveit2.repos
+     # Fetch latest repos
+     travis_run wget -O moveit.repos https://raw.githubusercontent.com/AcutronicRobotics/moveit2/master/moveit2.repos
+     travis_run vcs import src < moveit.repos
      travis_run_simple cd $ROS_WS/src
    else
      travis_run_simple cd $ROS_WS/src

--- a/travis.sh
+++ b/travis.sh
@@ -254,6 +254,14 @@ function build_workspace() {
    # Console output fix for: "WARNING: Could not encode unicode characters"
    export PYTHONIOENCODING=UTF-8
 
+   # Change to base of workspace
+   travis_run_simple cd $ROS_WS
+
+   # COLCON_IGNORE packages that cause the build to fail
+   # TODO: review this
+   travis_run_simple touch src/image_common/camera_calibration_parsers/COLCON_IGNORE
+   travis_run_simple touch src/image_common/camera_info_manager/COLCON_IGNORE
+
    # For a command that doesn’t produce output for more than 10 minutes, prefix it with travis_run_wait
    COLCON_CMAKE_ARGS="--cmake-args $CMAKE_ARGS --catkin-cmake-args $CMAKE_ARGS --ament-cmake-args $CMAKE_ARGS"
    travis_run_wait 60 --title "colcon build" colcon build $COLCON_CMAKE_ARGS $COLCON_EVENT_HANDLING

--- a/travis.sh
+++ b/travis.sh
@@ -57,7 +57,7 @@ function run_docker() {
 
     # Start Docker container
     docker run \
-        --net=host \
+        --network=host \
         -e TRAVIS \
         -e MOVEIT_CI_TRAVIS_TIMEOUT=$(travis_timeout $MOVEIT_CI_TRAVIS_TIMEOUT) \
         -e ROS_REPO \

--- a/travis.sh
+++ b/travis.sh
@@ -238,7 +238,7 @@ function prepare_ros_workspace() {
    travis_run --title "List files in ROS workspace's source folder" ls --color=auto -alhF
 
    # Install source-based package dependencies
-   travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO --skip-keys moveit_msgs octomap_msgs object_recognition_msgs
+   travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO --skip-keys moveit_msgs --skip-keys octomap_msgs --skip-keys object_recognition_msgs
 
    # Change to base of workspace
    travis_run_simple cd $ROS_WS

--- a/travis.sh
+++ b/travis.sh
@@ -57,6 +57,7 @@ function run_docker() {
 
     # Start Docker container
     docker run \
+        --net=host \
         -e TRAVIS \
         -e MOVEIT_CI_TRAVIS_TIMEOUT=$(travis_timeout $MOVEIT_CI_TRAVIS_TIMEOUT) \
         -e ROS_REPO \

--- a/travis.sh
+++ b/travis.sh
@@ -237,7 +237,7 @@ function prepare_ros_workspace() {
    travis_run --title "List files in ROS workspace's source folder" ls --color=auto -alhF
 
    # Install source-based package dependencies
-   travis_run_true rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO
+   travis_run rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO
 
    # Change to base of workspace
    travis_run_simple cd $ROS_WS

--- a/travis_functions.sh
+++ b/travis_functions.sh
@@ -31,6 +31,10 @@ travis_nanoseconds() {
     format='+%s000000000'
   fi
 
+  if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+    format='+%s000000000'
+  fi
+
   "${cmd}" -u "${format}"
 }
 travis_time_start() {

--- a/util.sh
+++ b/util.sh
@@ -79,8 +79,13 @@ travis_timeout() {
 # travis_fold (start|end) [name] [message]
 travis_fold() {
   # option -g declares those arrays globally!
-  declare -ag _TRAVIS_FOLD_NAME_STACK  # "stack" array to hold name hierarchy
-  declare -Ag _TRAVIS_FOLD_COUNTERS  # associated array to hold global counters
+
+  if [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+    :
+  else
+    declare -ag _TRAVIS_FOLD_NAME_STACK  # "stack" array to hold name hierarchy
+    declare -Ag _TRAVIS_FOLD_COUNTERS  # associated array to hold global counters
+  fi
 
   local action="$1"
   local name="${2:-moveit_ci}"  # name defaults to moveit_ci


### PR DESCRIPTION
This PR aims to align with the development happening at https://github.com/acutronicrobotics/moveit2 while fixes several of the problems that the existing infrastructure has when enabling any of the moveit2 submodules. Roughly:
- current moveit_ci (`ros2` branch) does not take in consideration several dependencies required to build from source moveit2
- Dockerfile (and docker images) used in the hub seem to be missing relevant dependencies, an attempt has been made to manually install what's required but decided instead to build new images from ground-up. Available at https://github.com/AcutronicRobotics/moveit2/blob/master/.docker/ci/Dockerfile. (note that this images build from a simple bionic container https://github.com/AcutronicRobotics/moveit2/blob/master/.docker/ci/Dockerfile#L1 instead of from the Open Robotics images). 
  - Images in the hub to accelerate the process available at https://cloud.docker.com/repository/docker/acutronicrobotics/moveit2/general
- Includes support for OS X. Current moveit_ci required changes for launching from OS X (which still uses the Docker container)
- Some ROS packages aren't fully ported and need to be COLCON_IGNORED in the workspace
- Disable warnings as errors