### PR TITLE
only build tests for the package being tested

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -259,7 +259,7 @@ function test_workspace() {
    test -n "$blacklist_pkgs" && catkin config --append-args --blacklist $blacklist &> /dev/null
 
    # Build tests
-   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests --
+   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- $PACKAGE_NAME
    # Run tests, suppressing the output (confuses Travis display?)
    travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize 2>/dev/null"
 


### PR DESCRIPTION
I am not sure why this wasn't the default before but it seems rather useful to keep ci times down