### PR TITLE
replacing ROS_REPO with DOCKER_IMAGE and MOVEIT_BRANCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ notifications:
 env:
   global: # default values
     - ROS_DISTRO=melodic
-    - ROS_REPO=ros
+    - DOCKER_IMAGE=melodic-ci
+    - MOVEIT_BRANCH=melodic-devel
     - SCRIPT=travis.sh
   matrix:
     - SCRIPT=unit_tests.sh
@@ -23,10 +24,10 @@ env:
     - SCRIPT=unit_tests.sh   SKIP=clang-tidy-check   ROS_DISTRO=kinetic
 
     # Build MoveIt! repository, moveit_ros_perception blacklisted due to lack of GPU-based docker env
-    - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
+    - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$MOVEIT_BRANCH/moveit.rosinstall
       TEST="clang-format, catkin_lint"
       CI_SOURCE_PATH=moveit # manually specify main source repo (not coincides with moveit_ci)
-    - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
+    - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$MOVEIT_BRANCH/moveit.rosinstall
       TEST_BLACKLIST=moveit_ros_perception   WARNINGS_OK=no
       CI_SOURCE_PATH=moveit # manually specify main source repo (not coincides with moveit_ci)
 
@@ -38,10 +39,10 @@ env:
 matrix:
   allow_failures: # While the above tests are proper unit tests, testing external workspaces has the risk of external issues
     # Build MoveIt! repository, moveit_ros_perception blacklisted due to lack of GPU-based docker env
-    - env: UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
+    - env: UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$MOVEIT_BRANCH/moveit.rosinstall
            TEST="clang-format, catkin_lint"
            CI_SOURCE_PATH=moveit # manually specify main source repo (not coincides with moveit_ci)
-    - env: UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/moveit.rosinstall
+    - env: UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-planning/moveit/$MOVEIT_BRANCH/moveit.rosinstall
            TEST_BLACKLIST=moveit_ros_perception   WARNINGS_OK=no
            CI_SOURCE_PATH=moveit # manually specify main source repo (not coincides with moveit_ci)
 

--- a/travis.sh
+++ b/travis.sh
@@ -35,13 +35,7 @@ function run_docker() {
    echo -e $(colorize YELLOW "Testing branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'")
    run_script BEFORE_DOCKER_SCRIPT
 
-    # Choose the docker container to use
-    case "${ROS_REPO:-ros}" in
-       ros) export DOCKER_IMAGE=moveit/moveit:$ROS_DISTRO-ci ;;
-       ros-shadow-fixed) export DOCKER_IMAGE=moveit/moveit:$ROS_DISTRO-ci-shadow-fixed ;;
-       *) echo -e $(colorize RED "Unsupported ROS_REPO=$ROS_REPO. Use 'ros' or 'ros-shadow-fixed'"); exit 1 ;;
-    esac
-
+    # Echo the docker container to be used
     echo -e $(colorize BOLD "Starting Docker image: $DOCKER_IMAGE")
     travis_run docker pull $DOCKER_IMAGE
 
@@ -49,7 +43,7 @@ function run_docker() {
     docker run \
         -e TRAVIS \
         -e MOVEIT_CI_TRAVIS_TIMEOUT=$(travis_timeout $MOVEIT_CI_TRAVIS_TIMEOUT) \
-        -e ROS_REPO \
+        -e MOVEIT_BRANCH \
         -e ROS_DISTRO \
         -e BEFORE_SCRIPT \
         -e CI_SOURCE_PATH=${CI_SOURCE_PATH:-/root/$REPOSITORY_NAME} \

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -48,8 +48,8 @@ PASSED=0 # reset count after ASSERT_TRUE
 
 # set default environment
 export ROS_WS=/tmp/ros_ws
-export ROS_REPO=ros
 export ROS_DISTRO=${ROS_DISTRO:-melodic}
+export MOVEIT_BRANCH=${MOVEIT_BRANCH:-melodic-devel}
 export WARNINGS_OK=true
 
 # dummy functions to skip updates with --no-updates functions


### PR DESCRIPTION
This takes a stab at allowing the user to explicitly select the moveit branch and docker image to use for ci rather than inferring it from other variables