### PR TITLE
WIP: Changing the default ROS_WS, forwarding it to Docker, and merging .rosinstall

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -165,7 +165,7 @@ function prepare_ros_workspace() {
 
    # If the workspace is already built, source it
    if [[ ! -f devel/setup.bash ]]; then
-     travis_run source devel/setup.bash
+     travis_run source ../devel/setup.bash
    fi
    # Pull additional packages into the ros workspace
    if [[ ! -f .rosinstall ]]; then
@@ -196,10 +196,9 @@ function prepare_ros_workspace() {
    if [ -e .rosinstall ]; then
       # ensure that the to-be-tested package is not in .rosinstall
       travis_run_true wstool rm $REPOSITORY_NAME
-      # perform shallow checkout: only possible with wstool init
-      travis_run_simple mv .rosinstall rosinstall
-      travis_run cat rosinstall
-      travis_run wstool init merge -r -y rosinstall
+      # perform checkout with wstool merge
+      travis_run cat .rosinstall
+      travis_run wstool merge -r -y .rosinstall
    fi
 
    # Link in the repo we are testing

--- a/travis.sh
+++ b/travis.sh
@@ -196,6 +196,7 @@ function prepare_ros_workspace() {
    if [ -e .rosinstall ]; then
       # ensure that the to-be-tested package is not in .rosinstall
       travis_run_true wstool rm $REPOSITORY_NAME
+      travis_run_true rm -rf $REPOSITORY_NAME
       # perform checkout with wstool merge
       travis_run cat .rosinstall
       travis_run wstool merge -r -y .rosinstall

--- a/travis.sh
+++ b/travis.sh
@@ -11,7 +11,7 @@
 
 export MOVEIT_CI_DIR=$(dirname ${BASH_SOURCE:-$0})  # path to the directory running the current script
 export REPOSITORY_NAME=$(basename $PWD) # name of repository, travis originally checked out
-export ROS_WS=${ROS_WS:-/root/ros_ws} # location of ROS workspace
+export ROS_WS=${ROS_WS:-/root/ws_moveit} # location of ROS workspace
 
 # Travis' default timeout for open source projects is 50 mins
 # If your project has a larger timeout, specify this variable in your .travis.yml file!
@@ -56,6 +56,7 @@ function run_docker() {
         -e MOVEIT_CI_TRAVIS_TIMEOUT=$(travis_timeout $MOVEIT_CI_TRAVIS_TIMEOUT) \
         -e ROS_REPO \
         -e ROS_DISTRO \
+        -e ROS_WS \
         -e BEFORE_SCRIPT \
         -e CI_SOURCE_PATH=${CI_SOURCE_PATH:-/root/$REPOSITORY_NAME} \
         -e UPSTREAM_WORKSPACE \

--- a/travis.sh
+++ b/travis.sh
@@ -167,9 +167,6 @@ function prepare_ros_workspace() {
    if [[ ! -f devel/setup.bash ]]; then
      travis_run source devel/setup.bash
    fi
-   if [[ ! -f .rosinstall ]]; then
-     travis_run wstool init .
-   fi
    # Pull additional packages into the ros workspace
    if [[ ! -f .rosinstall ]]; then
      travis_run wstool init .
@@ -202,7 +199,7 @@ function prepare_ros_workspace() {
       # perform shallow checkout: only possible with wstool init
       travis_run_simple mv .rosinstall rosinstall
       travis_run cat rosinstall
-      travis_run wstool init --shallow . rosinstall
+      travis_run wstool init merge -r -y rosinstall
    fi
 
    # Link in the repo we are testing

--- a/travis.sh
+++ b/travis.sh
@@ -163,7 +163,9 @@ function prepare_ros_workspace() {
    travis_run_simple cd $ROS_WS/src
 
    # Pull additional packages into the ros workspace
-   travis_run wstool init .
+   if [[ ! -f .rosinstall ]]; then
+     travis_run wstool init .
+   fi
    for item in $(unify_list " ,;" ${UPSTREAM_WORKSPACE:-debian}) ; do
       echo "Adding $item"
       case "$item" in
@@ -181,7 +183,7 @@ function prepare_ros_workspace() {
          http://* | https://* | file://*) ;; # use url as is
          *) item="file://$CI_SOURCE_PATH/$item" ;; # turn into proper url
       esac
-      travis_run_true wstool merge -k $item
+      travis_run_true wstool merge -r -y $item
       test $? -ne 0 && echo -e "$(colorize RED Failed to find rosinstall file. Aborting.)" && exit 2
    done
 

--- a/travis.sh
+++ b/travis.sh
@@ -162,6 +162,14 @@ function prepare_ros_workspace() {
    travis_run_simple mkdir -p $ROS_WS/src
    travis_run_simple cd $ROS_WS/src
 
+
+   # If the workspace is already built, source it
+   if [[ ! -f devel/setup.bash ]]; then
+     travis_run source devel/setup.bash
+   fi
+   if [[ ! -f .rosinstall ]]; then
+     travis_run wstool init .
+   fi
    # Pull additional packages into the ros workspace
    if [[ ! -f .rosinstall ]]; then
      travis_run wstool init .


### PR DESCRIPTION
This changes the default workspace to match the moveit docker images and forwards it to the Docker image.

Also, this changes the default behavior to check for an existing workspace and if one is found, then it merges the new rosinstall with the old defaulting to replacing existing repos rather than keeping the old.  

In the future, we should investigate using workspace underlays like in ROS2 rather than modifying the moveit workspace. 

This is being used by https://github.com/ros-planning/moveit_tutorials/pull/313