### PR TITLE
underlay support

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -68,7 +68,7 @@ function run_docker() {
         -e CFLAGS \
         -e CXXFLAGS \
         -v $(pwd):/root/$REPOSITORY_NAME \
-        -v $HOME/.ccache:/root/.ccache \
+        -v ${CCACHE_DIR:-$HOME/.ccache}:/root/.ccache \
         -t \
         -w /root/$REPOSITORY_NAME \
         $DOCKER_IMAGE /root/$REPOSITORY_NAME/.moveit_ci/travis.sh


### PR DESCRIPTION
This extends `moveit_ci` such that we can build against an arbitrary `ROS_UNDERLAY` as defined in the docker image used. This will, e.g., allow building against a pre-built MoveIt workspace (as provided in `source` docker image).
Note, that this PR also includes #61.

If this is merged, we might want to consider pruning of .rosinstall files of downstream packages (e.g. moveit_tutorials and moveit_visual_tools) and built against the `source` docker container instead.

**Please use a merge-commit to merge this PR.** All three commits are meaningful on their own.