### PR TITLE
Wrapped `rosdep update` in travis_retry

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -106,7 +106,7 @@ function update_system() {
    export PATH=/usr/lib/ccache:$PATH
 
    # Setup rosdep - note: "rosdep init" is already setup in base ROS Docker image
-   travis_run rosdep update
+   travis_retry rosdep update
 
    travis_fold end update
 }


### PR DESCRIPTION
Attempting to fix the many `rosdep update` timeouts that have been happening in  https://github.com/ros-planning/moveit/pull/1424.   ([build](https://travis-ci.org/ros-planning/moveit/builds/528802538?utm_source=github_status&utm_medium=notification)). 

[Travis itself](https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies) suggests using `travis_retry` to mitigate network timeouts, so hopefully this makes the CI a little more resilient. 