### PR TITLE
Allow moveit_ci to be used with any ROS docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - SCRIPT=travis.sh
   matrix:
     # Run docker with custom image
-    - SCRIPT=unit_tests.sh   ROS_REPO=               DOCKER_IMAGE=moveit/moveit:master-ci
+    - SCRIPT=unit_tests.sh   ROS_REPO=               DOCKER_IMAGE=ros:melodic-ros-base
     # Skip clang-tidy-check on Xenial. It's only supported for cmake >= 3.6. clang-tidy-fix is tested.
     - SCRIPT=unit_tests.sh   SKIP=clang-tidy-check   ROS_DISTRO=kinetic
 

--- a/travis.sh
+++ b/travis.sh
@@ -35,7 +35,7 @@ function run_docker() {
 
     # Choose the docker container to use
     if [ -n "$ROS_REPO" ] && [ -n "$DOCKER_IMAGE" ]; then
-       echo -e $(colorize YELLOW "$DOCKER_IMAGE overrides $ROS_REPO setting")
+       echo -e $(colorize YELLOW "DOCKER_IMAGE=$DOCKER_IMAGE overrides ROS_REPO=$ROS_REPO setting")
     fi
     if [ -z "$DOCKER_IMAGE" ]; then
        test -z "$ROS_DISTRO" && echo -e $(colorize RED "ROS_DISTRO not defined: cannot infer docker image") && exit 2


### PR DESCRIPTION
This allows use moveit_ci for non-MoveIt docker containers.
So far, we relied on the container to define this variable.