### PR TITLE
speedup clang-tidy-fix by processing modified files only

### DIFF
--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -3,7 +3,7 @@
 # Author:  Robert Haschke
 
 _travis_run_clang_tidy_fix() {
-    local SOURCE_PKGS COMPILED_PKGS counter pkg file
+    local SOURCE_PKGS COMPILED_PKGS counter pkg file src_dir strip_prefix
     SOURCE_PKGS=($(catkin_topological_order $CI_SOURCE_PATH --only-names 2> /dev/null))
 
     # filter repository packages for those which have a compile_commands.json file in their build folder
@@ -16,7 +16,27 @@ _travis_run_clang_tidy_fix() {
     for pkg in ${SOURCE_PKGS[@]} ; do  # process files in topological order
         test -z "${PKGS[$pkg]:-}" && continue  # skip pkgs without compile_commands.json
         travis_fold start clang.tidy "  - $(colorize BLUE Processing $pkg)"
-        travis_run_wait "$RUN_CLANG_TIDY_EXECUTABLE -fix -p ${PKGS[$pkg]} 2> /dev/null"
+
+        # Find all .cpp files in pkg's src_dir that were added or modified in this pull request
+        # If we are not processing a Travis pull request, check all files
+        # To enable unit-testing, check all files when $TEST_PKG is defined
+        modified_files=()
+        if [ "${TRAVIS_PULL_REQUEST:-false}" != false ] && [ -z "$TEST_PKG" ] ; then
+            src_dir=$(grep "^CMAKE_HOME_DIRECTORY:INTERNAL=" "${PKGS[$pkg]}/CMakeCache.txt")
+            src_dir=$(realpath "${src_dir#*=}")
+            strip_prefix=$(cd "$src_dir"; git rev-parse --show-toplevel)
+            strip_prefix="${src_dir#$strip_prefix/}"
+            while IFS='' read -r line ; do
+                modified_files+=("${line#$strip_prefix/}")
+            done < <(git diff --name-only --diff-filter=AM "$TRAVIS_BRANCH"..HEAD "$src_dir" | grep "\.cpp$")
+            if [ ${#modified_files[@]} -eq 0 ]; then
+                echo "No modified .cpp files"
+                travis_fold end clang.tidy
+                continue
+            fi
+        fi
+
+        travis_run_wait "$RUN_CLANG_TIDY_EXECUTABLE" -fix -p "${PKGS[$pkg]}" ${modified_files[@]} 2> /dev/null
         # if there are workspace changes, print broken pkg to file descriptor 3
         travis_have_fixes && 1>&3 echo $pkg || true  # should always succeed ;-)
         travis_fold end clang.tidy
@@ -31,7 +51,7 @@ RUN_CLANG_TIDY_EXECUTABLE=$(ls -1 /usr/bin/run-clang-tidy* | head -1)
 test -z "$RUN_CLANG_TIDY_EXECUTABLE" && \
    echo -e $(colorize YELLOW $(colorize THIN "Missing run-clang-tidy. Aborting.")) && \
    exit 2
-# Check whether -quiet options is supported
+# Check whether -quiet option is supported
 test ! $RUN_CLANG_TIDY_EXECUTABLE -quiet 2>&1 | grep -- "-quiet" > /dev/null && RUN_CLANG_TIDY_EXECUTABLE="$RUN_CLANG_TIDY_EXECUTABLE -quiet"
 
 # Run _travis_run_clang_tidy_fix() and redirect file descriptor 3 to /tmp/clang-tidy.tainted to collect tainted pkgs

--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -3,7 +3,7 @@
 # Author:  Robert Haschke
 
 _travis_run_clang_tidy_fix() {
-    local SOURCE_PKGS COMPILED_PKGS counter pkg file src_dir strip_prefix
+    local SOURCE_PKGS COMPILED_PKGS counter pkg file src_dir
     SOURCE_PKGS=($(catkin_topological_order $CI_SOURCE_PATH --only-names 2> /dev/null))
 
     # filter repository packages for those which have a compile_commands.json file in their build folder
@@ -23,12 +23,7 @@ _travis_run_clang_tidy_fix() {
         modified_files=()
         if [ "${TRAVIS_PULL_REQUEST:-false}" != false ] && [ -z "$TEST_PKG" ] ; then
             src_dir=$(grep "^CMAKE_HOME_DIRECTORY:INTERNAL=" "${PKGS[$pkg]}/CMakeCache.txt")
-            src_dir=$(realpath "${src_dir#*=}")
-            strip_prefix=$(cd "$src_dir"; git rev-parse --show-toplevel)
-            strip_prefix="${src_dir#$strip_prefix/}"
-            while IFS='' read -r line ; do
-                modified_files+=("${line#$strip_prefix/}")
-            done < <(git diff --name-only --diff-filter=AM "$TRAVIS_BRANCH"..HEAD "$src_dir" | grep "\.cpp$")
+            collect_modified_files modified_files "\.cpp$" $(realpath "${src_dir#*=}") $TRAVIS_BRANCH
             if [ ${#modified_files[@]} -eq 0 ]; then
                 echo "No modified .cpp files"
                 travis_fold end clang.tidy
@@ -36,7 +31,7 @@ _travis_run_clang_tidy_fix() {
             fi
         fi
 
-        travis_run_wait "$RUN_CLANG_TIDY_EXECUTABLE" -fix -p "${PKGS[$pkg]}" ${modified_files[@]} 2> /dev/null
+        travis_run_wait "$RUN_CLANG_TIDY_EXECUTABLE" -fix -p "${PKGS[$pkg]}" ${modified_files[@]:-} 2> /dev/null
         # if there are workspace changes, print broken pkg to file descriptor 3
         travis_have_fixes && 1>&3 echo $pkg || true  # should always succeed ;-)
         travis_fold end clang.tidy

--- a/util.sh
+++ b/util.sh
@@ -348,3 +348,20 @@ function colorize() {
    done
    echo -e "${color:-}$@${reset:-}"
 }
+
+# collect files that are modified since commit
+function collect_modified_files() {
+  local -n __modified_files=$1     # -n to modify argument by reference
+  local filter=$2
+  local src_dir=${3:-$PWD}
+  local base=${4:-$TRAVIS_BRANCH}
+
+  # Find top-level git folder of src_dir
+  local strip_prefix=$(cd "$src_dir"; git rev-parse --show-toplevel)
+  # Strip git folder from src_dir to keep relative path from git root to source files as stip_prefix
+  strip_prefix="${src_dir#$strip_prefix/}"
+  while IFS='' read -r line ; do
+    # Add modified or added files to array - only using the relative path from src_dir, i.e. removing strip_prefix
+    __modified_files+=("${line#$strip_prefix/}")
+  done < <(git diff --name-only --diff-filter=MA "$base"..HEAD "$src_dir" | grep "$filter")
+}


### PR DESCRIPTION
This implements https://github.com/ros-planning/moveit/issues/1487.