### PR TITLE
Enable unbound variable checking in bash scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - SCRIPT=travis.sh
   matrix:
     # Run docker with custom image
-    - SCRIPT=unit_tests.sh   ROS_REPO=               DOCKER_IMAGE=moveit/moveit:master-ci
+    - SCRIPT=unit_tests.sh   ROS_REPO=               DOCKER_IMAGE=ros:melodic-ros-base
     # Skip clang-tidy-check on Xenial. It's only supported for cmake >= 3.6. clang-tidy-fix is tested.
     - SCRIPT=unit_tests.sh   SKIP=clang-tidy-check   ROS_DISTRO=kinetic
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ script:
 ## Configurations
 
 - There are essentially two options two specify the underlying ROS docker container to use:
-  1. Using the two variables `ROS_DISTRO` and `ROS_REPO`, which automagically choose a suitable [MoveIt docker image](https://hub.docker.com/r/moveit/moveit/tags). 
+  1. Using the two variables `ROS_DISTRO` and `ROS_REPO`, which automagically choose a suitable [MoveIt docker image](https://hub.docker.com/r/moveit/moveit/tags).
      - `ROS_DISTRO`: (required) determines which version of ROS to use, i.e. kinetic, melodic, ...
      - `ROS_REPO`: (default: ros) determines which ROS package repository to use, either the regular release repo or, specifying `ros-shadow-fixed`, the [shadow prerelease repo](http://wiki.ros.org/ShadowRepository).
   2. Directly specifying `DOCKER_IMAGE`, e.g. `DOCKER_IMAGE=moveit/moveit:master-source`. The docker image may define a `ROS_UNDERLAY` to build the catkin workspace against. By default, this is the root ROS folder in /opt/ros.

--- a/travis.sh
+++ b/travis.sh
@@ -35,7 +35,7 @@ function run_docker() {
 
     # Choose the docker container to use
     if [ -n "$ROS_REPO" ] && [ -n "$DOCKER_IMAGE" ]; then
-       echo -e $(colorize YELLOW "$DOCKER_IMAGE overrides $ROS_REPO setting")
+       echo -e $(colorize YELLOW "DOCKER_IMAGE=$DOCKER_IMAGE overrides ROS_REPO=$ROS_REPO setting")
     fi
     if [ -z "$DOCKER_IMAGE" ]; then
        test -z "$ROS_DISTRO" && echo -e $(colorize RED "ROS_DISTRO not defined: cannot infer docker image") && exit 2

--- a/travis.sh
+++ b/travis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -u
 # -*- indent-tabs-mode: nil  -*-
 
 # Software License Agreement - BSD License
@@ -22,7 +22,7 @@ source ${MOVEIT_CI_DIR}/util.sh
 # usage: run_script BEFORE_SCRIPT  or run_script BEFORE_DOCKER_SCRIPT
 function run_script() {
    local script
-   eval "script=\$$1"  # fetch value of variable passed in $1 (double indirection)
+   eval "script=\${$1:-}"  # fetch value of variable passed in $1 (double indirection)
    if [ "${script// }" != "" ]; then  # only run when non-empty
       travis_run --title "$(colorize BOLD Running $1)" $script
       result=$?
@@ -34,10 +34,10 @@ function run_docker() {
    run_script BEFORE_DOCKER_SCRIPT
 
     # Choose the docker container to use
-    if [ -n "$ROS_REPO" ] && [ -n "$DOCKER_IMAGE" ]; then
+    if [ -n "$ROS_REPO" ] && [ -n "${DOCKER_IMAGE:=}" ]; then
        echo -e $(colorize YELLOW "DOCKER_IMAGE=$DOCKER_IMAGE overrides ROS_REPO=$ROS_REPO setting")
     fi
-    if [ -z "$DOCKER_IMAGE" ]; then
+    if [ -z "${DOCKER_IMAGE:=}" ]; then
        test -z "$ROS_DISTRO" && echo -e $(colorize RED "ROS_DISTRO not defined: cannot infer docker image") && exit 2
        case "${ROS_REPO:-ros}" in
           ros) export DOCKER_IMAGE=moveit/moveit:$ROS_DISTRO-ci ;;
@@ -58,6 +58,7 @@ function run_docker() {
         -e CI_SOURCE_PATH=${CI_SOURCE_PATH:-/root/$REPOSITORY_NAME} \
         -e UPSTREAM_WORKSPACE \
         -e TRAVIS_BRANCH \
+        -e TRAVIS_OS_NAME \
         -e TEST \
         -e TEST_BLACKLIST \
         -e WARNINGS_OK \
@@ -93,7 +94,7 @@ function update_system() {
    travis_run --retry apt-get -qq install -y wget sudo python-catkin-tools xvfb mesa-utils ccache
 
    # Install clang-format if needed
-   [[ "$TEST" == *clang-format* ]] && travis_run --retry apt-get -qq install -y clang-format-3.9
+   [[ "${TEST:=}" == *clang-format* ]] && travis_run --retry apt-get -qq install -y clang-format-3.9
    # Install clang-tidy stuff if needed
    [[ "$TEST" == *clang-tidy* ]] && travis_run --retry apt-get -qq install -y clang-tidy-6.0 clang-6.0
    # run-clang-tidy is part of clang-tools in Bionic, but not in Xenial -> ignore failure
@@ -118,7 +119,7 @@ function prepare_or_run_early_tests() {
    if ! [ -d "$CI_SOURCE_PATH" ] ; then return 0; fi
 
    # EARLY_RESULT="" -> no early exit, EARLY_RESULT=0 -> early success, otherwise early failure
-   local EARLY_RESULT
+   local EARLY_RESULT=""
    for t in $(unify_list " ,;" "$TEST") ; do
       case "$t" in
          clang-format)
@@ -253,7 +254,7 @@ function test_workspace() {
    travis_run_simple --title "Sourcing newly built install space" source install/setup.bash
 
    # Consider TEST_BLACKLIST
-   TEST_BLACKLIST=$(unify_list " ,;" $TEST_BLACKLIST)
+   TEST_BLACKLIST=$(unify_list " ,;" ${TEST_BLACKLIST:-})
    echo -e $(colorize YELLOW Test blacklist: $(colorize THIN $TEST_BLACKLIST))
    test -n "$TEST_BLACKLIST" && catkin config --blacklist $TEST_BLACKLIST &> /dev/null
 
@@ -261,7 +262,7 @@ function test_workspace() {
    all_pkgs=$(catkin_topological_order $ROS_WS --only-names 2> /dev/null)
    source_pkgs=$(catkin_topological_order $CI_SOURCE_PATH --only-names 2> /dev/null)
    blacklist_pkgs=$(filter_out "$source_pkgs" "$all_pkgs")
-   test -n "$blacklist_pkgs" && catkin config --append-args --blacklist $blacklist &> /dev/null
+   test -n "$blacklist_pkgs" && catkin config --append-args --blacklist $blacklist_pkgs &> /dev/null
 
    # Build tests
    travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests --
@@ -285,20 +286,23 @@ function test_workspace() {
 # This repository has some dummy catkin packages in folder test_pkgs, which are needed for unit testing only.
 # To not clutter normal builds, we just create a CATKIN_IGNORE file in that folder.
 # A unit test can be recognized from the presence of the environment variable $TEST_PKG (see unit_tests.sh)
-test -z "$TEST_PKG" && touch ${MOVEIT_CI_DIR}/test_pkgs/CATKIN_IGNORE # not a unit test build
+if [ -z "${TEST_PKG:-}" ]; then
+  touch ${MOVEIT_CI_DIR}/test_pkgs/CATKIN_IGNORE # not a unit test build
+fi
 
 # Re-run the script in a Docker container
-if ! [ "$IN_DOCKER" ]; then run_docker; fi
-echo -e $(colorize YELLOW "Testing branch '$TRAVIS_BRANCH' of '$REPOSITORY_NAME' on ROS '$ROS_DISTRO'")
+if [ "${IN_DOCKER:-0}" != "1" ]; then run_docker; fi
+echo -e $(colorize YELLOW "Testing branch '${TRAVIS_BRANCH:-}' of '${REPOSITORY_NAME:-}' on ROS '$ROS_DISTRO'")
 
 # If we are here, we can assume we are inside a Docker container
 echo "Inside Docker container"
 
 export ROS_WS=${ROS_WS:-/root/ros_ws} # default location of ROS workspace, if not defined differently in docker container
+CMAKE_ARGS=""
 
 # Prepend current dir if path is not yet absolute
 [[ "$MOVEIT_CI_DIR" != /* ]] && MOVEIT_CI_DIR=$PWD/$MOVEIT_CI_DIR
-if [[ "$CI_SOURCE_PATH" != /* ]] ; then
+if [[ "${CI_SOURCE_PATH:=}" != /* ]] ; then
    # If CI_SOURCE_PATH is not yet absolute
    if [ -d "$PWD/$CI_SOURCE_PATH" ] ; then
       CI_SOURCE_PATH=$PWD/$CI_SOURCE_PATH  # prepend with current dir, if that's feasible

--- a/travis_functions.sh
+++ b/travis_functions.sh
@@ -27,7 +27,7 @@ travis_nanoseconds() {
 
   if hash gdate >/dev/null 2>&1; then
     cmd='gdate'
-  elif [[ "${TRAVIS_OS_NAME}" == osx ]]; then
+  elif [[ "${TRAVIS_OS_NAME:-}" == osx ]]; then
     format='+%s000000000'
   fi
 

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -u
 
 #********************************************************************
 # Software License Agreement (BSD License)
@@ -64,7 +64,7 @@ all_groups="sanity warnings catkin_lint clang-format clang-tidy-fix clang-tidy-c
 skip_groups="${SKIP:-}"
 # process options
 while true ; do
-	case "$1" in
+	case "${1:-}" in
 		--quiet|-q) QUIET=/dev/null ;;  # suppress bulk of test's stdout
 		--no-docker) export IN_DOCKER=1 ;; # run without docker
 		--no-updates) export -f apt-get; export -f rosdep ;;


### PR DESCRIPTION
This is a rebase of #69 introducing bash setting -u to check for unbound variables.
This requires to introduce (usually empty) default values for most variables.

Additionally, this includes some changes to allow moveit_ci to be used with any ROS-based docker image (#72).