### PR TITLE
Ignore workspace changes prior to clang-format

### DIFF
--- a/check_clang_format.sh
+++ b/check_clang_format.sh
@@ -14,6 +14,9 @@ if [ ! -f .clang-format ]; then
         wget -nv "https://raw.githubusercontent.com/ros-planning/moveit/$ROS_DISTRO-devel/.clang-format"
 fi
 
+# To ignore current workspace changes (e.g. from Git LFS files), stage all current changes
+git add -u .
+
 # Run clang-format
 cmd="find . -name '*.h' -or -name '*.hpp' -or -name '*.cpp' | xargs clang-format-3.9 -i -style=file"
 travis_run --display "Running clang-format${ANSI_RESET}\\n$cmd" "$cmd"

--- a/util.sh
+++ b/util.sh
@@ -288,9 +288,9 @@ travis_monitor() {
 
 # Check repository for changes, return success(0) if there are changes
 travis_have_fixes() {
-  if ! git diff-index --quiet HEAD -- . ; then  # check for changes in current dir
+  if ! git diff --quiet . ; then  # check for changes in current dir
     echo -e $(colorize RED "\\nThe following issues were detected:")
-    git --no-pager diff
+    git --no-pager diff .
     git checkout . # undo changes in current dir
     return 0
   fi


### PR DESCRIPTION
Alternative implementation for #71.