### PR TITLE
[WIP] Postpone "early tests" until the catkin work space is fully setup

### DIFF
--- a/check_catkin_lint.sh
+++ b/check_catkin_lint.sh
@@ -5,9 +5,14 @@
 
 travis_fold start check.catkin_lint "Checking for issues reported by catkin_lint"
 
+# Skip external packages
+all_pkgs=$(catkin_topological_order $ROS_WS --only-names 2> /dev/null)
+source_pkgs=$(catkin_topological_order $CI_SOURCE_PATH --only-names 2> /dev/null)
+skip_pkgs=$(filter_out "$source_pkgs" "$all_pkgs")
+skip_args=$(for pkg in $skip_pkgs ; do echo -n "--skip-pkg $pkg "; done)
+
 travis_run catkin_lint --version
-travis_run --title "Running catkin_lint in repository source: $CI_SOURCE_PATH" \
-    catkin_lint $CI_SOURCE_PATH
+travis_run --title "Running catkin_lint" catkin_lint $skip_args $ROS_WS
 result=$?
 
 # Finish fold before printing result summary

--- a/travis.sh
+++ b/travis.sh
@@ -60,6 +60,7 @@ function run_docker() {
         -e TRAVIS_BRANCH \
         -e TRAVIS_PULL_REQUEST \
         -e TRAVIS_OS_NAME \
+        -e TEST_PKG \
         -e TEST \
         -e TEST_BLACKLIST \
         -e WARNINGS_OK \

--- a/travis.sh
+++ b/travis.sh
@@ -114,11 +114,8 @@ function update_system() {
    travis_fold end update
 }
 
-function prepare_or_run_early_tests() {
+function run_early_tests() {
    # Check for different tests. clang-format and catkin_lint will trigger an early exit
-   # However, they can only run when $CI_SOURCE_PATH is already available. If not try later again.
-   if ! [ -d "$CI_SOURCE_PATH" ] ; then return 0; fi
-
    # EARLY_RESULT="" -> no early exit, EARLY_RESULT=0 -> early success, otherwise early failure
    local EARLY_RESULT=""
    for t in $(unify_list " ,;" "$TEST") ; do
@@ -324,10 +321,9 @@ test ${WARNINGS_OK:=true} == true -o "$WARNINGS_OK" == 1 -o "$WARNINGS_OK" == ye
 travis_run --title "CXX compiler info" $CXX --version
 
 update_system
-prepare_or_run_early_tests
 run_xvfb
 prepare_ros_workspace
-prepare_or_run_early_tests
+run_early_tests
 
 build_workspace
 test_workspace


### PR DESCRIPTION
Addresses #80. `catkin_lint` should run only after the workspace has been setup.