### PR TITLE
Use vcstool for cloning workspace dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ script:
 - `UPSTREAM_WORKSPACE` (default: debian): Configure additional packages for your ROS workspace.
   By default, all dependent packages will be downloaded as binary packages from `$ROS_REPO`.
   Setting this variable to a `http://github.com/user/repo#branch` repository url, will clone the corresponding repository into the workspace.
-  Setting this variable to a `http://` url, or a local file in your repository, will merge the corresponding `.rosinstall` file with [`wstool`](http://wiki.ros.org/wstool) into your workspace.
+  Setting this variable to a `http://` url, or a local file in your repository, will merge the corresponding `.rosinstall` or `.repos` file with [`vcstool`](https://github.com/dirk-thomas/vcstool) into your workspace.
 Multiple sources can be given as a comma-, or semicolon-separated lists. Note: their order matters -- if the same resource is defined twice, only the first one is considered.
 - `TEST_BLACKLIST`: Allow certain tests to be skipped if necessary (not recommended).
 - `TEST`: list of additional tests to perform: clang-format, clang-tidy-check, clang-tidy-fix, catkin\_lint

--- a/travis.sh
+++ b/travis.sh
@@ -96,7 +96,7 @@ function update_system() {
    # Make sure the packages are up-to-date
    travis_run --retry apt-get -qq dist-upgrade
    # Install required packages (if not yet provided by docker container)
-   travis_run --retry apt-get -qq install -y wget sudo xvfb mesa-utils ccache
+   travis_run --retry apt-get -qq install -y wget curl sudo xvfb mesa-utils ccache
 
    # Install clang-format if needed
    [[ "${TEST:=}" == *clang-format* ]] && travis_run --retry apt-get -qq install -y clang-format-3.9
@@ -180,7 +180,7 @@ function prepare_ros_workspace() {
          http://* | https://* | file://*) ;; # use url as is
          *) item="file://$CI_SOURCE_PATH/$item" ;; # turn into proper url
       esac
-      travis_run_true wget -q -O $UPSTREAM_WORKSPACE_FILE $item
+      travis_run_true curl -s -o $UPSTREAM_WORKSPACE_FILE $item
       test $? -ne 0 && echo -e "$(colorize RED Failed to find rosinstall file. Aborting.)" && exit 2
    done
 

--- a/travis.sh
+++ b/travis.sh
@@ -192,8 +192,9 @@ function prepare_ros_workspace() {
    # Download upstream packages into workspace
    if [ -e $UPSTREAM_WORKSPACE_FILE ]; then
       travis_run mkdir upstream
+      travis_run cat $UPSTREAM_WORKSPACE_FILE
       # clone all package dependencies
-      travis_run vcs import --repos --skip-existing --input $UPSTREAM_WORKSPACE_FILE upstream
+      travis_run vcs import --skip-existing --input $UPSTREAM_WORKSPACE_FILE upstream
       # remove to-be-tested package if it has been cloned from a different repository
       if [ -d "upstream/$REPOSITORY_NAME" ]; then
          travis_run rm -r "upstream/$REPOSITORY_NAME"

--- a/travis.sh
+++ b/travis.sh
@@ -191,9 +191,13 @@ function prepare_ros_workspace() {
 
    # Download upstream packages into workspace
    if [ -e $UPSTREAM_WORKSPACE_FILE ]; then
-      travis_run cat $UPSTREAM_WORKSPACE_FILE
-      # skip the to-be-tested repo if it is specified inside the repos/rosinstall file
-      travis_run vcs import --skip-existing < $UPSTREAM_WORKSPACE_FILE
+      travis_run mkdir upstream
+      # clone all package dependencies
+      travis_run vcs import --repos --skip-existing --input $UPSTREAM_WORKSPACE_FILE upstream
+      # remove to-be-tested package if it has been cloned from a different repository
+      if [ -d "upstream/$REPOSITORY_NAME" ]; then
+         travis_run rm -r "upstream/$REPOSITORY_NAME"
+      fi
    fi
 
    # Fetch clang-tidy configs


### PR DESCRIPTION
This adds support for cloning dependencies '.repos' files as commonly used with ROS2.
I tested this while fixing up Travis for moveit2: https://github.com/ros-planning/moveit2/pull/119
Test with .rosinstall: https://travis-ci.org/ros-planning/moveit2/builds/604968261#L351
Test with .repos: https://travis-ci.org/ros-planning/moveit2/builds/604990050#L363

In contrast to the previous implementation dependencies are not only removed if they have the same name as the to-be-tested repository, but also if they are from the same url.

Update: Fixed printing of upstream packages https://travis-ci.org/ros-planning/moveit2/builds/605026846#L411