### PR TITLE
Add codecov.io support

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -86,6 +86,7 @@ function run_docker() {
         -e TRAVIS_OS_NAME \
         -e TEST_PKG \
         -e TEST \
+        -e PKG_WHITELIST \
         -e TEST_BLACKLIST \
         -e WARNINGS_OK \
         -e ABI_BASE_URL \
@@ -279,7 +280,7 @@ function build_workspace() {
    export PYTHONIOENCODING=UTF-8
 
    # For a command that doesn’t produce output for more than 10 minutes, prefix it with travis_run_wait
-   travis_run_wait 60 --title "catkin build" catkin build --no-status --summarize
+   travis_run_wait 60 --title "catkin build" catkin build --no-status --summarize ${PKG_WHITELIST:-}
 
    # Allow to verify ccache usage
    travis_run --title "ccache statistics" ccache -s
@@ -306,9 +307,9 @@ function test_workspace() {
    test -n "$blacklist_pkgs" && catkin config --append-args --blacklist $blacklist_pkgs &> /dev/null
 
    # Build tests
-   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests --
+   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- ${PKG_WHITELIST:-}
    # Run tests, suppressing the output (confuses Travis display?)
-   travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize 2>/dev/null"
+   travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize ${PKG_WHITELIST:-} 2>/dev/null"
 
    # Show failed tests
    travis_fold start test.results "catkin_test_results"

--- a/travis.sh
+++ b/travis.sh
@@ -396,14 +396,18 @@ for t in $(unify_list " ,;" "$TEST") ; do
          test $? -eq 0 || result=$(( ${result:-0} + 1 ))
          ;;
       code-coverage)
-         # Run gcov manually to redirect its output to /dev/null
-         gcov_ignore="-not -path '*/test/*'"
-         travis_run --title "Running gcov" \
-            find $ROS_WS -type f -name '*.gcno' $gcov_ignore -execdir gcov -pb {} + > /dev/null
-         # Run codecov.io's script to collect and upload reports
-         travis_run --title "Collect and upload reports to codecov.io" \
-            bash <(curl -s https://codecov.io/bash) -Z -X gcov -s $ROS_WS \
-            -R $ROS_WS/src/$REPOSITORY_NAME | grep -ve "\w+\+"
+         travis_fold start codecov.io "Generate and upload code coverage report"
+         # Capture coverage info
+         travis_run "lcov --capture --directory $ROS_WS --output-file coverage.info | grep -ve '^Processing'"
+         # Extract repository files
+         travis_run "lcov --extract coverage.info \"$ROS_WS/src/$REPOSITORY_NAME/*\" --output-file coverage.info | grep -ve '^Extracting'"
+         # Filter out test files
+         travis_run "lcov --remove coverage.info '*/test/*' --output-file coverage.info | grep -ve '^Removing'"
+         # Output coverage data for debugging
+         travis_run "lcov --list coverage.info"
+         # Upload to codecov.io: -f specifies file(s) to upload and disables manual coverage gathering
+         travis_run --title "Upload report" bash <(curl -s https://codecov.io/bash) -f coverage.info -R $ROS_WS/src/$REPOSITORY_NAME
+         travis_fold end codecov.io
          ;;
    esac
 done

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -60,7 +60,7 @@ rosdep() {
 	echo "Dummy rosdep $*"
 }
 
-all_groups="sanity warnings catkin_lint clang-format clang-tidy-fix clang-tidy-check code-coverage"
+all_groups="sanity warnings catkin_lint clang-format clang-tidy-fix clang-tidy-check"
 skip_groups="${SKIP:-}"
 # process options
 while true ; do
@@ -119,9 +119,6 @@ for group in $test_groups ; do
 		clang-tidy-check)  # only supported for cmake >= 3.6
 			run_test 0 $0:$LINENO "clang-tidy-check on 'valid' package, warnings forbidden" TEST_PKG=valid TEST=clang-tidy-check WARNINGS_OK=false
 			run_test 1 $0:$LINENO "clang-tidy-check on 'clang_tidy' package, warnings forbidden" TEST_PKG=clang_tidy TEST=clang-tidy-check WARNINGS_OK=false
-			;;
-		code-coverage)
-			run_test 0 $0:$LINENO "code-coverage on 'valid' package, warnings forbidden" TEST_PKG=valid TEST=code-coverage WARNINGS_OK=false
 			;;
 		*) echo -e $(colorize YELLOW "Unknown test group '$group'.")
 			echo "Known groups are: $all_groups" ;;

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -60,7 +60,7 @@ rosdep() {
 	echo "Dummy rosdep $*"
 }
 
-all_groups="sanity warnings catkin_lint clang-format clang-tidy-fix clang-tidy-check"
+all_groups="sanity warnings catkin_lint clang-format clang-tidy-fix clang-tidy-check code-coverage"
 skip_groups="${SKIP:-}"
 # process options
 while true ; do
@@ -119,6 +119,9 @@ for group in $test_groups ; do
 		clang-tidy-check)  # only supported for cmake >= 3.6
 			run_test 0 $0:$LINENO "clang-tidy-check on 'valid' package, warnings forbidden" TEST_PKG=valid TEST=clang-tidy-check WARNINGS_OK=false
 			run_test 1 $0:$LINENO "clang-tidy-check on 'clang_tidy' package, warnings forbidden" TEST_PKG=clang_tidy TEST=clang-tidy-check WARNINGS_OK=false
+			;;
+		code-coverage)
+			run_test 0 $0:$LINENO "code-coverage on 'valid' package, warnings forbidden" TEST_PKG=valid TEST=code-coverage WARNINGS_OK=false
 			;;
 		*) echo -e $(colorize YELLOW "Unknown test group '$group'.")
 			echo "Known groups are: $all_groups" ;;


### PR DESCRIPTION
Further improvement of #91:
- Avoid debug build to speed up test runs
- Use lcov to facilitate filtering of relevant source files

I successfully tested this on MoveIt and rviz. From my point of view this is ready for merging.
@tylerjw, @davetcoleman: Please have a look.