### PR TITLE
Remove hard-coded 60min build time

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -294,7 +294,7 @@ function build_workspace() {
    export PYTHONIOENCODING=UTF-8
 
    # For a command that doesn’t produce output for more than 10 minutes, prefix it with travis_run_wait
-   travis_run_wait 60 --title "catkin build" catkin build --no-status --summarize ${PKG_WHITELIST:-}
+   travis_run_wait --title "catkin build" catkin build --no-status --summarize ${PKG_WHITELIST:-}
 }
 
 function test_workspace() {

--- a/util.sh
+++ b/util.sh
@@ -241,7 +241,7 @@ travis_run() {
   travis_run_true --assert "$@"
 }
 
-# Run command(s) with a timeout (of 20min by default)
+# Run command(s) with a timeout (remaining time by default)
 travis_run_wait() {
   # parse first parameter as timeout and drop it if successful
   local timeout


### PR DESCRIPTION
This was replaced with the remaining overall time in b66a50a7ea7ec489888c47edb92c7aea1ee8ec2a.