### PR TITLE
Switch Travis email recipient to Tyler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ compiler: gcc
 
 notifications:
   email:
-    recipients:
-       - tyler@picknik.ai
+
 env:
   global: # default values
     - ROS_DISTRO=melodic

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ compiler: gcc
 notifications:
   email:
     recipients:
-       - dave@dav.ee
+       - tyler@picknik.ai
 env:
   global: # default values
     - ROS_DISTRO=melodic


### PR DESCRIPTION
This has been going to my personal email, which does not make sense. @tylerjw are you ok with this or, @rhaschke would you like to be the notified one? Alternatively, it can be just blank.