### PR TITLE
print output of run_tests

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -319,8 +319,8 @@ function test_workspace() {
 
    # Build tests
    travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- ${PKG_WHITELIST:-}
-   # Run tests, suppressing the output (confuses Travis display?)
-   travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize ${PKG_WHITELIST:-} 2>/dev/null"
+   # Run tests
+   travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize ${PKG_WHITELIST:-}"
 
    # Show failed tests
    travis_fold start test.results "catkin_test_results"

--- a/travis.sh
+++ b/travis.sh
@@ -294,7 +294,7 @@ function build_workspace() {
    export PYTHONIOENCODING=UTF-8
 
    # For a command that doesn’t produce output for more than 10 minutes, prefix it with travis_run_wait
-   travis_run_wait 60 --title "catkin build" catkin build --no-status --summarize ${PKG_WHITELIST:-}
+   travis_run_wait --title "catkin build" catkin build --no-status --summarize ${PKG_WHITELIST:-}
 }
 
 function test_workspace() {

--- a/util.sh
+++ b/util.sh
@@ -241,7 +241,7 @@ travis_run() {
   travis_run_true --assert "$@"
 }
 
-# Run command(s) with a timeout (of 20min by default)
+# Run command(s) with a timeout (remaining time by default)
 travis_run_wait() {
   # parse first parameter as timeout and drop it if successful
   local timeout


### PR DESCRIPTION
I'd like to diskuss keeping run_tests output.

`2>/dev/null` was appended in b66a50a7ea7ec489888c47edb92c7aea1ee8ec2a with a comment "confuses Travis display?"

In the case of failed tests, error output is very helpful and dropping it very costly (especially for tests passing locally). I cannot see any travis confusion in the display of test builds:
* [failing job](https://travis-ci.org/PilzDE/pilz_teach/jobs/633805103?utm_medium=notification&utm_source=github_status)
* [successful job](https://travis-ci.org/PilzDE/pilz_teach/builds/633806828?utm_medium=notification&utm_source=github_status)

built with the fork of this PR.

Could you explain the issue why you discarded the output?

Also note that [industrial_ci](https://github.com/ros-industrial/industrial_ci/blob/d714f67ea998fb214d2a58e78227f9729640deac/industrial_ci/src/tests/source_tests.sh#L236)  prints the output of `run_tests`.