### PR TITLE
WIP: blacklist by removing packages from the set of built and run tests

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -305,20 +305,24 @@ function test_workspace() {
    travis_run_simple --title "Sourcing newly built install space" source install/setup.bash
    test -n "$old_ustatus" && set -u  # restore variable checking option
 
-   # format blacklist as a list
-   TEST_BLACKLIST=$(unify_list " ,;" ${TEST_BLACKLIST:-})
-   echo -e $(colorize YELLOW Test blacklist: $(colorize THIN $TEST_BLACKLIST))
+   # Build whitelist of packages if it wasn't specified
+   if [ -z "${PKG_WHITELIST:-}" ]; then
+      PKG_WHITELIST=$(catkin_topological_order $CI_SOURCE_PATH --only-names)
 
-   # build whitelist of packages
-   local source_pkgs
-   source_pkgs=$(catkin_topological_order $CI_SOURCE_PATH --only-names)
-   source_pkgs=$(filter_out "${TEST_BLACKLIST:-}" "$source_pkgs")
-   echo -e $(colorize GREEN Source pkgs: $(colorize THIN $source_pkgs))
-   test -z "${PKG_WHITELIST:-}" && PKG_WHITELIST=$source_pkgs
+      # Filter out for blacklist
+      if [ -n "${TEST_BLACKLIST:-}" ]; then
+         TEST_BLACKLIST=$(unify_list " ,;" ${TEST_BLACKLIST:-})
+         echo -e $(colorize YELLOW Test blacklist: $(colorize THIN $TEST_BLACKLIST))
+         PKG_WHITELIST=$(filter_out "$TEST_BLACKLIST" "$PKG_WHITELIST")
+      fi
+   fi
 
-   # Build tests
+   # Print the packages we will now test
+   echo -e $(colorize GREEN Testing pkgs: $(colorize THIN $PKG_WHITELIST))
+
+   # Build tests (and dependencies)
    travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- ${PKG_WHITELIST}
-   # Run tests
+   # Run tests (without dependencies, this is so we only test the whitelist)
    travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize --no-deps ${PKG_WHITELIST}"
 
    # Show failed tests

--- a/travis.sh
+++ b/travis.sh
@@ -305,16 +305,17 @@ function test_workspace() {
    travis_run_simple --title "Sourcing newly built install space" source install/setup.bash
    test -n "$old_ustatus" && set -u  # restore variable checking option
 
-   # Blacklist explicit and external packages
    local source_pkgs
    source_pkgs=$(catkin_topological_order $CI_SOURCE_PATH --only-names)
-   source_pkgs=$(filter_out "$TEST_BLACKLIST" "$source_pkgs")
+   TEST_BLACKLIST=$(unify_list " ,;" ${TEST_BLACKLIST:-})
+   source_pkgs=$(filter_out "${TEST_BLACKLIST:-}" "$source_pkgs")
    echo -e $(colorize GREEN Source pkgs: $(colorize THIN $source_pkgs))
+   test -z "${PKG_WHITELIST:-}" && PKG_WHITELIST=$source_pkgs
 
    # Build tests
-   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- ${PKG_WHITELIST:source_pkgs}
+   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- ${PKG_WHITELIST}
    # Run tests
-   travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize --no-deps ${PKG_WHITELIST:source_pkgs}"
+   travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize --no-deps ${PKG_WHITELIST}"
 
    # Show failed tests
    travis_fold start test.results "catkin_test_results"

--- a/travis.sh
+++ b/travis.sh
@@ -320,8 +320,6 @@ function test_workspace() {
    # Print the packages we will now test
    echo -e $(colorize GREEN Testing pkgs: $(colorize THIN $PKG_WHITELIST))
 
-   # Build tests (and dependencies)
-   travis_run_wait --title "catkin build tests" catkin build --no-status --summarize --make-args tests -- ${PKG_WHITELIST}
    # Run tests (without dependencies, this is so we only test the whitelist)
    travis_run_wait --title "catkin run_tests" "catkin build --catkin-make-args run_tests -- --no-status --summarize --no-deps ${PKG_WHITELIST}"
 

--- a/travis.sh
+++ b/travis.sh
@@ -305,9 +305,13 @@ function test_workspace() {
    travis_run_simple --title "Sourcing newly built install space" source install/setup.bash
    test -n "$old_ustatus" && set -u  # restore variable checking option
 
+   # format blacklist as a list
+   TEST_BLACKLIST=$(unify_list " ,;" ${TEST_BLACKLIST:-})
+   echo -e $(colorize YELLOW Test blacklist: $(colorize THIN $TEST_BLACKLIST))
+
+   # build whitelist of packages
    local source_pkgs
    source_pkgs=$(catkin_topological_order $CI_SOURCE_PATH --only-names)
-   TEST_BLACKLIST=$(unify_list " ,;" ${TEST_BLACKLIST:-})
    source_pkgs=$(filter_out "${TEST_BLACKLIST:-}" "$source_pkgs")
    echo -e $(colorize GREEN Source pkgs: $(colorize THIN $source_pkgs))
    test -z "${PKG_WHITELIST:-}" && PKG_WHITELIST=$source_pkgs


### PR DESCRIPTION
To fix the bug where blacklisted packages are removed from the workspace creating a situation where they are linked from debians.

Fixes: https://github.com/ros-planning/moveit/issues/2042