### PR TITLE
Add missing default value for ROS_PYTHON_VERSION

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -133,7 +133,7 @@ function update_system() {
    # Update the sources
    travis_run --retry apt-get -qq update
 
-   if [ "$ROS_PYTHON_VERSION" == "3" ]; then
+   if [ "${ROS_PYTHON_VERSION:=2}" == "3" ]; then
        travis_run --retry apt-get -qq install -y git python3-pip
        travis_run pip3 install git+https://github.com/catkin/catkin_tools.git
    else


### PR DESCRIPTION
This is required for old Indigo builds, which don't yet know about ROS_PYTHON_VERSION.
This is blocking https://github.com/ros-planning/moveit_resources/pull/36.