### PR TITLE
Increase default timeout

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -65,7 +65,7 @@ travis_timeout() {
     result=0  # $1 looks like integer that should be consumed as a parameter
   else
     result=1  # parameter shouldn't be consumed
-    timeout=20  # default timeout
+    timeout=45  # default timeout
   fi
 
   # remaining time in minutes (default timeout for open-source Travis jobs is 50min)


### PR DESCRIPTION
https://travis-ci.com/github/ros-planning/moveit/jobs/392457017 hit the default timeout, although there is plenty of time left for the overall travis job time limit.