### PR TITLE
Source underlay before building the overlay workspace

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -279,7 +279,7 @@ function prepare_ros_workspace() {
 
    # Source the underlay workspace
    set +u  # disable unbound variable checking when sourcing setup.bash
-   travis_run_simple --title "Sourcing the underlay workspace" source "${ROS_UNDERLAY:-/opt/ros/$ROS_DISTRO}/setup.bash"
+   travis_run_simple source "${ROS_UNDERLAY:-/opt/ros/$ROS_DISTRO}/setup.bash"
    set -u  # re-enable unbound variable checking
 
    # Install source-based package dependencies

--- a/travis.sh
+++ b/travis.sh
@@ -285,6 +285,10 @@ function prepare_ros_workspace() {
 
    # Validate that we have some packages to build
    test -z "$(colcon list)" && echo -e "$(colorize RED Workspace $ROS_WS has no packages to build. Terminating.)" && exit 1
+
+   # Source the UNDERLAY workspace
+   travis_run_simple --title "Sourcing the underlay workspace" source "${ROS_UNDERLAY:-/opt/ros/$ROS_DISTRO}"
+
    travis_fold end ros.ws
 }
 

--- a/travis.sh
+++ b/travis.sh
@@ -208,6 +208,15 @@ function run_xvfb() {
 
 function prepare_ros_workspace() {
    travis_fold start ros.ws "Setting up ROS workspace"
+
+   # Make sure to source the underlay workspace before building the overlay
+   if [ -n "$ROS_UNDERLAY" ]; then
+    local old_ustatus=${-//[^u]/}
+    set +u  # disable checking for unbound variables for the next line
+    travis_run_simple --title "Sourcing the underlay workspace" source $ROS_UNDERLAY/setup.bash
+    test -n "$old_ustatus" && set -u  # restore variable checking option
+   fi
+
    travis_run_simple mkdir -p $ROS_WS/src
    travis_run_simple cd $ROS_WS/src
 

--- a/travis.sh
+++ b/travis.sh
@@ -278,7 +278,9 @@ function prepare_ros_workspace() {
    travis_run --title "List files in ROS workspace's source folder" ls --color=auto -alhF . "$upstream_folder"
 
    # Source the underlay workspace
+   set +u  # disable unbound variable checking when sourcing setup.bash
    travis_run_simple --title "Sourcing the underlay workspace" source "${ROS_UNDERLAY:-/opt/ros/$ROS_DISTRO}/setup.bash"
+   set -u  # re-enable unbound variable checking
 
    # Install source-based package dependencies
    travis_run --retry rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO

--- a/travis.sh
+++ b/travis.sh
@@ -208,15 +208,6 @@ function run_xvfb() {
 
 function prepare_ros_workspace() {
    travis_fold start ros.ws "Setting up ROS workspace"
-
-   # Make sure to source the underlay workspace before building the overlay
-   if [ -n "$ROS_UNDERLAY" ]; then
-    local old_ustatus=${-//[^u]/}
-    set +u  # disable checking for unbound variables for the next line
-    travis_run_simple --title "Sourcing the underlay workspace" source $ROS_UNDERLAY/setup.bash
-    test -n "$old_ustatus" && set -u  # restore variable checking option
-   fi
-
    travis_run_simple mkdir -p $ROS_WS/src
    travis_run_simple cd $ROS_WS/src
 

--- a/travis.sh
+++ b/travis.sh
@@ -277,6 +277,9 @@ function prepare_ros_workspace() {
    travis_run_simple cd $ROS_WS/src
    travis_run --title "List files in ROS workspace's source folder" ls --color=auto -alhF . "$upstream_folder"
 
+   # Source the underlay workspace
+   travis_run_simple --title "Sourcing the underlay workspace" source "${ROS_UNDERLAY:-/opt/ros/$ROS_DISTRO}/setup.bash"
+
    # Install source-based package dependencies
    travis_run --retry rosdep install -y -q -n --from-paths . --ignore-src --rosdistro $ROS_DISTRO
 
@@ -285,9 +288,6 @@ function prepare_ros_workspace() {
 
    # Validate that we have some packages to build
    test -z "$(colcon list)" && echo -e "$(colorize RED Workspace $ROS_WS has no packages to build. Terminating.)" && exit 1
-
-   # Source the UNDERLAY workspace
-   travis_run_simple --title "Sourcing the underlay workspace" source "${ROS_UNDERLAY:-/opt/ros/$ROS_DISTRO}"
 
    travis_fold end ros.ws
 }


### PR DESCRIPTION
In ROS2 to extend the overlay we need to source the underlay's `install/setup.bash` file, otherwise `rosdep` will install the packages in the underlay from `apt` and will fail if they don't exist

This blocks https://github.com/ros-planning/moveit_task_constructor/pull/170