### PR TITLE
Validate codecov uploader before executing.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -411,8 +411,12 @@ for t in $(unify_list " ,;" "$TEST") ; do
          travis_run "lcov --remove coverage.info '*/test/*' --output-file coverage.info | grep -ve '^Removing'"
          # Output coverage data for debugging
          travis_run "lcov --list coverage.info"
+         # Download and validate codecov bash uploader script
+         travis_run --title "Download codecov uploader" "curl -s 'https://codecov.io/bash' > codecov"
+         local codecov_version="$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);"
+         travis_run --title "Validate codecov uploader" shasum -a 512 -c <(curl -s "https://raw.githubusercontent.com/codecov/codecov-bash/${codecov_version}/SHA512SUM" | grep -w codecov)
          # Upload to codecov.io: -f specifies file(s) to upload and disables manual coverage gathering
-         travis_run --title "Upload report" bash <(curl -s https://codecov.io/bash) -f coverage.info -R $ROS_WS/src/$REPOSITORY_NAME
+         travis_run --title "Upload report" bash codecov -f coverage.info -R $ROS_WS/src/$REPOSITORY_NAME
          travis_fold end codecov.io
          ;;
    esac


### PR DESCRIPTION
After the recent Codecov security incident[1] I've been reviewing
codecov usage across ROS repositories.

This script is fetching the codecov bash uploader and env scripts
without performing the recommended validation step.

The validation step does not appear to have been widely explained or
publicised and even the official codecov GitHub action was not
validating the script until the recent security incident.

I have made an attempt to validate the bash uploader here.
The environment script is also used but early enough in the process that
it wasn't convenient to validate with my lack of familiarity in the
travis scripting style.

If there's interest I can probably refactor this to fetch and validate
both scripts during the setup phase instead of trying to do the bash
uploader inline. However I wanted to start with a minimal change.

[1]: https://about.codecov.io/security-update/

Author's note: I initially pushed this branch directly to the moveit_ci parent repository in my capacity as an org owner. I have deleted that branch and re-opened the PR from my own fork. Maintainer edits are enabled.
